### PR TITLE
Avoid relative paths to make tests pass

### DIFF
--- a/aequilibrae_menu.py
+++ b/aequilibrae_menu.py
@@ -12,22 +12,22 @@ from typing import Dict
 from warnings import warn
 
 import qgis
-from .modules.common_tools import AboutDialog
-from .modules.matrix_procedures import LoadDatasetDialog
-from .modules.menu_actions import run_add_zones, display_aequilibrae_formats, run_show_project_data, load_matrices
-from .modules.menu_actions import run_desire_lines, run_scenario_comparison, run_lcd, run_tag, run_add_connectors
-from .modules.menu_actions import run_distribution_models, run_tsp, run_change_parameters, run_stacked_bandwidths
-from .modules.menu_actions import run_load_project, project_from_osm, run_create_transponet, prepare_network, show_log
-from .modules.paths_procedures import run_shortest_path, run_dist_matrix, run_traffic_assig
-from .modules.public_transport_procedures import GtfsImportDialog
+from modules.common_tools import AboutDialog
+from modules.matrix_procedures import LoadDatasetDialog
+from modules.menu_actions import run_add_zones, display_aequilibrae_formats, run_show_project_data, load_matrices
+from modules.menu_actions import run_desire_lines, run_scenario_comparison, run_lcd, run_tag, run_add_connectors
+from modules.menu_actions import run_distribution_models, run_tsp, run_change_parameters, run_stacked_bandwidths
+from modules.menu_actions import run_load_project, project_from_osm, run_create_transponet, prepare_network, show_log
+from modules.paths_procedures import run_shortest_path, run_dist_matrix, run_traffic_assig
+from modules.public_transport_procedures import GtfsImportDialog
 from qgis.PyQt import QtCore
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QVBoxLayout, QApplication
 from qgis.PyQt.QtWidgets import QWidget, QDockWidget, QAction, QMenu, QTabWidget, QCheckBox, QToolBar, QToolButton
 from qgis.core import QgsDataSourceUri, QgsVectorLayer
 from qgis.core import QgsProject
-from .binary_downloader_class import BinaryDownloaderDialog
-from .download_extra_packages_class import DownloadExtraPackages
+from binary_downloader_class import BinaryDownloaderDialog
+from download_extra_packages_class import DownloadExtraPackages
 
 no_binary = False
 try:

--- a/download_extra_packages_class.py
+++ b/download_extra_packages_class.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 
 from qgis.PyQt import uic, QtWidgets
-from .modules.common_tools import ReportDialog
+from modules.common_tools import ReportDialog
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(os.path.dirname(__file__) + "/modules/forms/", "ui_package_downloader.ui"))
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,7 @@
 # import qgis libs so that ve set the correct sip api version
 
 import qgis  # pylint: disable=W0611  # NOQA
+import sys
+from os.path import abspath, join, dirname
+sys.path.insert(0, abspath(join(dirname(dirname(__file__)), "")))
+sys.path.insert(0, abspath(join(dirname(dirname(__file__)), "aequilibrae")))

--- a/tests/test_load_plugin.py
+++ b/tests/test_load_plugin.py
@@ -3,7 +3,7 @@ import unittest
 from qgis.utils import iface
 
 from .utilities import get_qgis_app
-from ..aequilibrae_menu import AequilibraEMenu
+from aequilibrae_menu import AequilibraEMenu
 
 class OpenMainDialogTest(unittest.TestCase):
     """Test dialog works."""


### PR DESCRIPTION
Looks like tests are passing without relative paths and  path.inserts in tests/__init__.py file.

Would this be acceptable, or are there side effects in regular project usage ?