### PR TITLE
Fix automatic package installation when using conda forge qgis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,11 @@ aequilibrae/paths/basic_path_finding.html
 aequilibrae/paths/parameters.html
 aequilibrae/paths/build/*
 
+qaequilibrae/requirements_to_do.txt
+
+__pycache__/
+
+
 
 # End of https://www.gitignore.io/api/jetbrains
 # qgis-plugin-ci

--- a/qaequilibrae/download_extra_packages_class.py
+++ b/qaequilibrae/download_extra_packages_class.py
@@ -58,15 +58,7 @@ class download_all:
         elif sys.platform == "darwin":
             python_exe = sys_exe.parent / "bin" / "python3"
         elif sys.platform == "win32":
-            python_exe = sys_exe.parent / "python3.exe"
-            if python_exe.exists():
-                return python_exe    
-            # Conda sys_exe is ~/.conda/envs/<envname>/Library/bin/qgis.exe,
-            # python is at ~/.conda/envs/<envname>/python.exe
-            conda_candidate = (sys_exe.parent.parent.parent / "python.exe")
-            if conda_candidate.exists():
-                return conda_candidate
-
+            python_exe = Path(sys.base_prefix) / "python.exe"
 
         if not python_exe.exists():
             raise FileExistsError("Can't find a python executable to use")

--- a/qaequilibrae/download_extra_packages_class.py
+++ b/qaequilibrae/download_extra_packages_class.py
@@ -59,9 +59,17 @@ class download_all:
             python_exe = sys_exe.parent / "bin" / "python3"
         elif sys.platform == "win32":
             python_exe = sys_exe.parent / "python3.exe"
+            if python_exe.exists():
+                return python_exe    
+            # Conda sys_exe is ~/.conda/envs/<envname>/Library/bin/qgis.exe,
+            # python is at ~/.conda/envs/<envname>/python.exe
+            conda_candidate = (sys_exe.parent.parent.parent / "python.exe")
+            if conda_candidate.exists():
+                return conda_candidate
+
 
         if not python_exe.exists():
-            raise FileExistsError("Can't find a python executable to use")
+            raise FileNotFoundError(f"Can't find a python executable to use")
         return python_exe
 
     def adapt_aeq_version(self):

--- a/qaequilibrae/download_extra_packages_class.py
+++ b/qaequilibrae/download_extra_packages_class.py
@@ -22,7 +22,7 @@ class download_all:
         self.adapt_aeq_version()
 
         lines = []
-        command = f'"{self.find_python()}" -m pip install -r "{self.file}" -t "{self.pth}" --upgrade'
+        command = f'"python" -m pip install -r "{self.file}" -t "{self.pth}" --upgrade'
         print(sys.executable)
         print(command)
         lines.append(command)
@@ -69,7 +69,7 @@ class download_all:
 
 
         if not python_exe.exists():
-            raise FileNotFoundError(f"Can't find a python executable to use")
+            raise FileExistsError("Can't find a python executable to use")
         return python_exe
 
     def adapt_aeq_version(self):

--- a/qaequilibrae/download_extra_packages_class.py
+++ b/qaequilibrae/download_extra_packages_class.py
@@ -22,7 +22,7 @@ class download_all:
         self.adapt_aeq_version()
 
         lines = []
-        command = f'"python" -m pip install -r "{self.file}" -t "{self.pth}" --upgrade'
+        command = f'"{self.find_python()}" -m pip install -r "{self.file}" -t "{self.pth}" --upgrade'
         print(sys.executable)
         print(command)
         lines.append(command)


### PR DESCRIPTION
I've been experimenting with using QGIS installed via conda-forge (same idea as [this](https://anitagraser.com/2023/01/21/pyqgis-jupyter-notebooks-on-windows-using-conda/)) as a way to keep qgis up to date more easily, and I noticed that the automatic pip install as part of the plugin download is broken when qgis is packaged in this way.

This was the traceback I got
```python
Traceback (most recent call last):
  File "C:\Users/Matt/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\qaequilibrae\qaequilibrae.py", line 33, in 
    from aequilibrae.project import Project
  File "C:\Users/Matt/.conda/envs/qgis/Library/./python\qgis\utils.py", line 888, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
ModuleNotFoundError: No module named 'aequilibrae'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users/Matt/.conda/envs/qgis/Library/./python\qgis\utils.py", line 423, in _startPlugin
    plugins[packageName] = package.classFactory(iface)
  File "C:\Users/Matt/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\qaequilibrae\__init__.py", line 3, in classFactory
    from .qaequilibrae import AequilibraEMenu
  File "C:\Users/Matt/.conda/envs/qgis/Library/./python\qgis\utils.py", line 888, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
  File "C:\Users/Matt/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\qaequilibrae\qaequilibrae.py", line 43, in 
    result = download_all().install()
  File "C:\Users/Matt/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\qaequilibrae\download_extra_packages_class.py", line 25, in install
    command = f'"{self.find_python()}" -m pip install -r "{self.file}" -t "{self.pth}" --upgrade'
  File "C:\Users/Matt/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\qaequilibrae\download_extra_packages_class.py", line 64, in find_python
    raise FileExistsError("Can't find a python executable to use")
FileExistsError: Can't find a python executable to use
```
and it seemed pretty straightforward to just add another condition to the windows path lookup.

As an aside, if the default was to use plain python `python`, rather than crash with a FileExistsError (or at least attempt to do so), as it looks like the behaviour was before #213 this would have worked without issue for me (based on testing, that, I wasn't able to install and old commit directly to check).

If this is considered out of scope that's fine too, I don't know if the assumption that qgis is bundled with a specific version of python is made, but installing from conda forge would break that - as you can specify qgis and python versions explicitly. 


(I also added some things to the gitignore that showed, but that might be a side effect of how I did my dev setup)


