### PR TITLE
Removes warnings from Add zoning data

### DIFF
--- a/qaequilibrae/modules/project_procedures/add_zones_procedure.py
+++ b/qaequilibrae/modules/project_procedures/add_zones_procedure.py
@@ -35,7 +35,6 @@ class AddZonesProcedure(WorkerThread):
                 zone.add_centroid(None)
             self.emit_messages(value=i + 1)
         self.jobFinished.emit("DONE")
-        self.close()
 
     def emit_messages(self, message="", value=-1, max_val=-1):
         if len(message) > 0:

--- a/qaequilibrae/modules/project_procedures/adds_zones_dialog.py
+++ b/qaequilibrae/modules/project_procedures/adds_zones_dialog.py
@@ -2,6 +2,8 @@ import os
 import sys
 
 import pandas as pd
+from aequilibrae.project.database_connection import database_connection
+from aequilibrae.utils.db_utils import commit_and_close
 from PyQt5.QtCore import Qt
 
 import qgis
@@ -66,34 +68,36 @@ class AddZonesDialog(QtWidgets.QDialog, FORM_CLASS):
         self.show()
 
     def changed_layer(self):
-        if not self.project or not self.project.conn:
-            return
-        ignore_fields = ["ogc_fid", "geometry"]
-        not_initializable = ["zone_id"]
+        with commit_and_close(database_connection("network")) as conn:
 
-        fields = pd.read_sql("PRAGMA table_info(zones)", self.project.conn).name.to_list()
-        fields = [x.lower() for x in fields if x not in ignore_fields]
+            if not self.project or not conn:
+                return
+            ignore_fields = ["ogc_fid", "geometry"]
+            not_initializable = ["zone_id"]
 
-        self.table_fields.clearContents()
-        self.table_fields.setRowCount(len(fields))
+            fields = pd.read_sql("PRAGMA table_info(zones)", conn).name.to_list()
+            fields = [x.lower() for x in fields if x not in ignore_fields]
 
-        layer_fields = self.cob_lyr.currentLayer().fields() if self.cob_lyr.currentLayer() else []
+            self.table_fields.clearContents()
+            self.table_fields.setRowCount(len(fields))
 
-        for counter, field in enumerate(fields):
-            item1 = QtWidgets.QTableWidgetItem(field)
-            item1.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
-            self.table_fields.setItem(counter, 1, item1)
+            layer_fields = self.cob_lyr.currentLayer().fields() if self.cob_lyr.currentLayer() else []
 
-            chb1 = QtWidgets.QCheckBox()
-            chb1.setChecked(True)
-            if field in not_initializable:
-                chb1.setEnabled(False)
-            self.table_fields.setCellWidget(counter, 0, self.centers_item(chb1))
+            for counter, field in enumerate(fields):
+                item1 = QtWidgets.QTableWidgetItem(field)
+                item1.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
+                self.table_fields.setItem(counter, 1, item1)
 
-            cbb = QtWidgets.QComboBox()
-            for i in layer_fields:
-                cbb.addItem(i.name())
-            self.table_fields.setCellWidget(counter, 2, self.centers_item(cbb))
+                chb1 = QtWidgets.QCheckBox()
+                chb1.setChecked(True)
+                if field in not_initializable:
+                    chb1.setEnabled(False)
+                self.table_fields.setCellWidget(counter, 0, self.centers_item(chb1))
+
+                cbb = QtWidgets.QComboBox()
+                for i in layer_fields:
+                    cbb.addItem(i.name())
+                self.table_fields.setCellWidget(counter, 2, self.centers_item(cbb))
 
     def centers_item(self, item):
         cell_widget = QWidget()
@@ -115,3 +119,6 @@ class AddZonesDialog(QtWidgets.QDialog, FORM_CLASS):
 
     def job_finished_from_thread(self, success):
         self.exit_procedure()
+
+    def exit_procedure(self):
+        self.close()


### PR DESCRIPTION
Add zoning data was returning a warning that _AddZonesDialog_ does not have an _exit_procedure_ attribute. 

Although zones were being created, we aimed to remove this warning by creating an _exit_procedure_ function in _add_zones_dialog_ and removing the _close_ statement from _add_zones_procedures_, we ended up with another warning, related to the database connection. This last issue was solved by adding a safe connection with AequililbraE's _commit_and_close_