### PR TITLE
BUG: Fix use of backgroundcolor in stacked bandwidths

### DIFF
--- a/qaequilibrae/modules/gis/create_bandwidths_dialog.py
+++ b/qaequilibrae/modules/gis/create_bandwidths_dialog.py
@@ -40,6 +40,7 @@ class CreateBandwidthsDialog(QDialog, FORM_CLASS):
         # layers and fields        # For adding skims
         self.mMapLayerComboBox.layerChanged.connect(self.add_fields_to_cboxes)
         self.mMapLayerComboBox.setFilters(QgsMapLayerProxyModel.LineLayer)
+        self.mMapLayerComboBox.setCurrentText(self.iface.activeLayer().name())
 
         self.ab_FieldComboBox.currentIndexChanged.connect(partial(self.choose_a_field, "AB"))
         self.ba_FieldComboBox.currentIndexChanged.connect(partial(self.choose_a_field, "BA"))

--- a/qaequilibrae/modules/gis/create_bandwidths_dialog.py
+++ b/qaequilibrae/modules/gis/create_bandwidths_dialog.py
@@ -40,7 +40,7 @@ class CreateBandwidthsDialog(QDialog, FORM_CLASS):
         # layers and fields        # For adding skims
         self.mMapLayerComboBox.layerChanged.connect(self.add_fields_to_cboxes)
         self.mMapLayerComboBox.setFilters(QgsMapLayerProxyModel.LineLayer)
-        self.mMapLayerComboBox.setCurrentText(self.iface.activeLayer().name())
+        self.mMapLayerComboBox.setLayer(self.iface.activeLayer())
 
         self.ab_FieldComboBox.currentIndexChanged.connect(partial(self.choose_a_field, "AB"))
         self.ba_FieldComboBox.currentIndexChanged.connect(partial(self.choose_a_field, "BA"))

--- a/qaequilibrae/modules/gis/create_bandwidths_dialog.py
+++ b/qaequilibrae/modules/gis/create_bandwidths_dialog.py
@@ -183,11 +183,11 @@ class CreateBandwidthsDialog(QDialog, FORM_CLASS):
 
         # if we clicked the "remove button"
         if column == 0 and row < self.tot_bands - 1:
-            low_cl = self.bands_list.item(row + 1, 2).backgroundColor()
+            low_cl = self.bands_list.item(row + 1, 2).background()
             low_ab = self.bands_list.item(row + 1, 0).text()
             low_ba = self.bands_list.item(row + 1, 1).text()
 
-            top_cl = self.bands_list.item(row, 2).backgroundColor()
+            top_cl = self.bands_list.item(row, 2).background()
             top_ab = self.bands_list.item(row, 0).text()
             top_ba = self.bands_list.item(row, 1).text()
 
@@ -200,11 +200,11 @@ class CreateBandwidthsDialog(QDialog, FORM_CLASS):
             self.bands_list.item(row + 1, 2).setBackground(top_cl)
 
         elif column == 1 and row > 0:
-            low_cl = self.bands_list.item(row, 2).backgroundColor()
+            low_cl = self.bands_list.item(row, 2).background()
             low_ab = self.bands_list.item(row, 0).text()
             low_ba = self.bands_list.item(row, 1).text()
 
-            top_cl = self.bands_list.item(row - 1, 2).backgroundColor()
+            top_cl = self.bands_list.item(row - 1, 2).background()
             top_ab = self.bands_list.item(row - 1, 0).text()
             top_ba = self.bands_list.item(row - 1, 1).text()
 
@@ -280,7 +280,7 @@ class CreateBandwidthsDialog(QDialog, FORM_CLASS):
                 # we also build a list of bands to construct
                 # The function "(2 * j -1) * ba"  maps the index j {1,2} and the direction to the side of the
                 # link the band needs to be. Try it out. it works!!
-                # bands.append((field, (2 * j -1) * ba, self.bands_list.item(i, 2).backgroundColor()))
+                # bands.append((field, (2 * j -1) * ba, self.bands_list.item(i, 2).background()))
             if len(self.bands_list.item(i, 2).text()) == 0:
                 cl = self.bands_list.item(i, 2).background().color()
             else:


### PR DESCRIPTION
In the stacked bandwidths dialogue:
![image](https://github.com/AequilibraE/qaequilibrae/assets/45483497/c0dcca93-b3fa-49b3-9512-fb40568433e2)
the up and down buttons don't seem to work on newer versions of QGIS:
![image](https://github.com/AequilibraE/qaequilibrae/assets/45483497/1d44a32b-c343-4907-a102-d6bc39fe35bc)

I'm seeing this on QGIS 3.34 (and I think 3.28 as well). I assume this is to do with the version of Qt (QGIS 3.34 comes with Qt 5.15.3) but I can't seem to find a corresponding changelog where backgroundColor was removed (apparently in the cpp it's just obsolete but not removed: https://doc.qt.io/qt-5/qtablewidgetitem-obsolete.html ?). I'm not sure of backwards compatibility requirements / what promises the qaequilbrae plugin makes, but `background` seems to exist back to Qt 4.2 (https://doc.qt.io/qt-5/qtablewidgetitem.html#background).

(I've also set the default layer in the stacked bandwidths dialogue to be the selected layer, but can revert that if it's not desired)
