### PR TITLE
Updates project layer creation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM qgis/qgis:release-3_32
+FROM qgis/qgis:release-3_34
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt update -y && apt install -y pandoc zip

--- a/.github/workflows/DevWorkflow.yml
+++ b/.github/workflows/DevWorkflow.yml
@@ -10,13 +10,11 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        container: [ 'qgis/qgis:latest', 'qgis/qgis:release-3_32']
+        container: [ 'qgis/qgis:latest', 'qgis/qgis:release-3_34']
     container:
       image: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Install dependencies
         run: |

--- a/qaequilibrae/modules/menu_actions/load_project_action.py
+++ b/qaequilibrae/modules/menu_actions/load_project_action.py
@@ -39,6 +39,9 @@ def _run_load_project_from_path(qgis_project, proj_path):
             else:
                 raise e
 
+    update_project_layers(qgis_project)
+
+def update_project_layers(qgis_project):
     curr = qgis_project.project.conn.cursor()
     curr.execute("select f_table_name from geometry_columns;")
     layers = [x[0] for x in curr.fetchall()]

--- a/qaequilibrae/modules/public_transport_procedures/gtfs_importer.py
+++ b/qaequilibrae/modules/public_transport_procedures/gtfs_importer.py
@@ -7,6 +7,7 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QDialog, QTableWidgetItem
 
 from qaequilibrae.modules.public_transport_procedures.gtfs_feed import GTFSFeed
+from qaequilibrae.modules.menu_actions.load_project_action import update_project_layers
 
 FORM_CLASS, _ = uic.loadUiType(join(dirname(__file__), "forms/gtfs_importer.ui"))
 
@@ -92,6 +93,9 @@ class GTFSImporter(QDialog, FORM_CLASS):
             feed.set_allow_map_match(True)
             feed.doWork()
 
+        self.qgis_project.projectManager.removeTab(0)
+        update_project_layers(self.qgis_project)
+
         self.close()
 
     def signal_handler(self, val):
@@ -101,7 +105,6 @@ class GTFSImporter(QDialog, FORM_CLASS):
         bar = self.progressBar if val[1] == "master" else self.progressBar2
         lbl = self.lbl_progress if val[1] == "master" else self.lbl_progress2
 
-        print(val)
         if val[0] == "start":
             lbl.setText(val[3])
             bar.setRange(0, val[2])


### PR DESCRIPTION
This PR:

* creates a function (_update_project_layers_) that can be reused in the code
* modifies the code in the gtfs_importer _execute_import_ function to delete and update the layers in the project if a GTFS is imported. 

This modification was done because when importing a GTFS to a project, and immediately trying to explore it using _Explore Transit_, an error regarding the existence of stops, routes, and pattern layers was displayed. This way we remove the error, and make the user experience a little better by updating the _Geo layers_ tab, which would only be updated the next time we opened the project.