### PR TITLE
Updates on Data Visualization menu

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM qgis/qgis:release-3_32
+FROM qgis/qgis:release-3_34
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt update -y && apt install -y pandoc zip

--- a/.github/workflows/DevWorkflow.yml
+++ b/.github/workflows/DevWorkflow.yml
@@ -10,13 +10,11 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        container: [ 'qgis/qgis:latest', 'qgis/qgis:release-3_32']
+        container: [ 'qgis/qgis:latest', 'qgis/qgis:release-3_34']
     container:
       image: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Install dependencies
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "iis.configDir": ""
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "iis.configDir": ""
+}

--- a/ci/requirements-dev.txt
+++ b/ci/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest-qgis
 pytest-qt
 pytest-cov
+pytest-mock

--- a/qaequilibrae/modules/matrix_procedures/display_aequilibrae_formats_dialog.py
+++ b/qaequilibrae/modules/matrix_procedures/display_aequilibrae_formats_dialog.py
@@ -178,10 +178,15 @@ class DisplayAequilibraEFormatsDialog(QtWidgets.QDialog, FORM_CLASS):
             self.add_matrix_parameters(idx, core)
             self.format_showing()
 
-    def export(self):
-        new_name, file_type = GetOutputFileName(
+    def csv_file_path(self):
+        new_name, _ = GetOutputFileName(
             self, self.data_type, ["Comma-separated file(*.csv)"], ".csv", self.data_path
         )
+        return new_name
+
+    def export(self):
+        new_name = self.csv_file_path()
+
         if new_name is not None:
             self.data_to_show.export(new_name)
 

--- a/qaequilibrae/modules/matrix_procedures/display_aequilibrae_formats_dialog.py
+++ b/qaequilibrae/modules/matrix_procedures/display_aequilibrae_formats_dialog.py
@@ -39,20 +39,7 @@ class DisplayAequilibraEFormatsDialog(QtWidgets.QDialog, FORM_CLASS):
             self.continue_with_data()
             return
 
-        formats = ["Aequilibrae matrix(*.aem)", "Aequilibrae dataset(*.aed)"]
-
-        dflt = ".aem"
-        if has_omx:
-            formats.insert(0, "Open Matrix(*.omx)")
-            dflt = ".omx"
-
-        self.data_path, self.data_type = GetOutputFileName(
-            self,
-            self.tr("AequilibraE custom formats"),
-            formats,
-            dflt,
-            standard_path(),
-        )
+        self.get_file_name()
 
         if self.data_type is None:
             self.error = self.tr("Path provided is not a valid dataset")
@@ -60,6 +47,10 @@ class DisplayAequilibraEFormatsDialog(QtWidgets.QDialog, FORM_CLASS):
         else:
             self.data_type = self.data_type.upper()
             self.continue_with_data()
+        
+        if self.error:
+            self.setWindowFlag(QtCore.Qt.WindowCloseButtonHint, True)
+            self.but_load.clicked.connect(self.get_file_name)
 
     def continue_with_data(self):
         self.setWindowTitle(self.tr("File path:").format(self.data_path))
@@ -214,3 +205,19 @@ class DisplayAequilibraEFormatsDialog(QtWidgets.QDialog, FORM_CLASS):
         self.data_to_show.matrix_view = np.array(self.omx[field])
         self.data_to_show.index = np.array(list(self.omx.mapping(idx).keys()))
         self.data_to_show.matrix[field] = self.data_to_show.matrix_view[:, :]
+
+    def get_file_name(self):
+        formats = ["Aequilibrae matrix(*.aem)", "Aequilibrae dataset(*.aed)"]
+
+        dflt = ".aem"
+        if has_omx:
+            formats.insert(0, "Open Matrix(*.omx)")
+            dflt = ".omx"
+
+        self.data_path, self.data_type = GetOutputFileName(
+            self,
+            self.tr("AequilibraE custom formats"),
+            formats,
+            dflt,
+            standard_path(),
+        )

--- a/qaequilibrae/modules/matrix_procedures/display_aequilibrae_formats_dialog.py
+++ b/qaequilibrae/modules/matrix_procedures/display_aequilibrae_formats_dialog.py
@@ -39,7 +39,7 @@ class DisplayAequilibraEFormatsDialog(QtWidgets.QDialog, FORM_CLASS):
             self.continue_with_data()
             return
 
-        self.get_file_name()
+        self.data_path, self.data_type = self.get_file_name()
 
         if self.data_type is None:
             self.error = self.tr("Path provided is not a valid dataset")
@@ -186,7 +186,7 @@ class DisplayAequilibraEFormatsDialog(QtWidgets.QDialog, FORM_CLASS):
             self.data_to_show.export(new_name)
 
     def exit_with_error(self):
-        qgis.utils.iface.messageBar().pushMessage("Error:", self.error, level=1)
+        qgis.utils.iface.messageBar().pushMessage("Error:", self.error, level=1, duration=10)
         self.close()
 
     def exit_procedure(self):
@@ -214,10 +214,12 @@ class DisplayAequilibraEFormatsDialog(QtWidgets.QDialog, FORM_CLASS):
             formats.insert(0, "Open Matrix(*.omx)")
             dflt = ".omx"
 
-        self.data_path, self.data_type = GetOutputFileName(
+        data_path, data_type = GetOutputFileName(
             self,
             self.tr("AequilibraE custom formats"),
             formats,
             dflt,
             standard_path(),
         )
+
+        return data_path, data_type

--- a/qaequilibrae/modules/matrix_procedures/forms/ui_project_data.ui
+++ b/qaequilibrae/modules/matrix_procedures/forms/ui_project_data.ui
@@ -43,7 +43,7 @@
       </font>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab_mat">
       <attribute name="title">

--- a/qaequilibrae/modules/matrix_procedures/load_project_data.py
+++ b/qaequilibrae/modules/matrix_procedures/load_project_data.py
@@ -7,7 +7,7 @@ from aequilibrae.project.database_connection import database_connection
 
 import qgis
 from qgis.PyQt import QtWidgets, uic
-from qgis.PyQt.QtWidgets import QAbstractItemView
+from qgis.PyQt.QtWidgets import QAbstractItemView, QTabWidget
 from qaequilibrae.modules.matrix_procedures.display_aequilibrae_formats_dialog import DisplayAequilibraEFormatsDialog
 from qaequilibrae.modules.matrix_procedures.load_result_table import load_result_table
 from qaequilibrae.modules.matrix_procedures.matrix_lister import list_matrices
@@ -22,31 +22,37 @@ has_omx = spec is not None
 
 
 class LoadProjectDataDialog(QtWidgets.QDialog, FORM_CLASS):
-    def __init__(self, qgs_proj):
+    def __init__(self, qgs_proj, proj=True):
         QtWidgets.QDialog.__init__(self)
         self.iface = qgs_proj.iface
         self.setupUi(self)
         self.data_to_show = None
         self.error = None
         self.qgs_proj = qgs_proj
-        self.project = qgs_proj.project
+        self.from_proj = proj
+        self.project = qgs_proj.project if self.from_proj else None
 
-        self.matrices: pd.DataFrame = None
-        self.matrices_model: PandasModel = None
+        if self.from_proj:
+            self.matrices: pd.DataFrame = None
+            self.matrices_model: PandasModel = None
 
-        self.results: pd.DataFrame = None
-        self.results_model: PandasModel = None
+            self.results: pd.DataFrame = None
+            self.results_model: PandasModel = None
 
-        for table in [self.list_matrices, self.list_results]:
-            table.setSelectionBehavior(QAbstractItemView.SelectRows)
-            table.setSelectionMode(QAbstractItemView.SingleSelection)
+            for table in [self.list_matrices, self.list_results]:
+                table.setSelectionBehavior(QAbstractItemView.SelectRows)
+                table.setSelectionMode(QAbstractItemView.SingleSelection)
 
-        self.load_matrices()
-        self.load_results()
+            self.load_matrices()
+            self.load_results()
 
-        self.but_update_matrices.clicked.connect(self.update_matrix_table)
-        self.but_load_Results.clicked.connect(self.load_result_table)
-        self.but_load_matrix.clicked.connect(self.display_matrix)
+            self.but_update_matrices.clicked.connect(self.update_matrix_table)
+            self.but_load_Results.clicked.connect(self.load_result_table)
+            self.but_load_matrix.clicked.connect(self.display_matrix)
+        else:
+            QTabWidget.setTabVisible(self.tabs, 0, False)
+            QTabWidget.setTabVisible(self.tabs, 1, False)
+        
         self.but_load_data.clicked.connect(self.display_external_data)
 
     def display_matrix(self):

--- a/qaequilibrae/modules/matrix_procedures/load_project_data.py
+++ b/qaequilibrae/modules/matrix_procedures/load_project_data.py
@@ -1,4 +1,3 @@
-import importlib.util as iutil
 import os
 from os.path import join
 import pandas as pd
@@ -15,10 +14,6 @@ from qaequilibrae.modules.matrix_procedures.results_lister import list_results
 from qaequilibrae.modules.common_tools import PandasModel
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(os.path.dirname(__file__), "forms/ui_project_data.ui"))
-
-# Checks if we can display OMX
-spec = iutil.find_spec("openmatrix")
-has_omx = spec is not None
 
 
 class LoadProjectDataDialog(QtWidgets.QDialog, FORM_CLASS):

--- a/qaequilibrae/modules/menu_actions/action_show_project_data.py
+++ b/qaequilibrae/modules/menu_actions/action_show_project_data.py
@@ -1,9 +1,8 @@
 def run_show_project_data(qgis_project):
     from qaequilibrae.modules.matrix_procedures import LoadProjectDataDialog
 
-    if qgis_project.project is None:
-        qgis_project.iface.messageBar().pushMessage("Error", "You need to load a project first", level=3, duration=10)
-        return
-    dlg2 = LoadProjectDataDialog(qgis_project)
+    has_project = False if qgis_project.project is None else True
+
+    dlg2 = LoadProjectDataDialog(qgis_project, has_project)
     dlg2.show()
     dlg2.exec_()

--- a/test/test_display_aequilibrae_formats.py
+++ b/test/test_display_aequilibrae_formats.py
@@ -1,0 +1,8 @@
+import pytest
+from qaequilibrae.modules.matrix_procedures.display_aequilibrae_formats_dialog import DisplayAequilibraEFormatsDialog
+
+
+# TODO:
+@pytest.mark.skip("")
+def test_display_data():
+    dialog = DisplayAequilibraEFormatsDialog()

--- a/test/test_display_aequilibrae_formats.py
+++ b/test/test_display_aequilibrae_formats.py
@@ -3,6 +3,20 @@ from qaequilibrae.modules.matrix_procedures.display_aequilibrae_formats_dialog i
 
 
 # TODO:
-@pytest.mark.skip("")
-def test_display_data():
-    dialog = DisplayAequilibraEFormatsDialog()
+def test_display_data_without_project(ae, mocker):
+    dialog = DisplayAequilibraEFormatsDialog(ae)
+
+    function = "qaequilibrae.modules.matrix_procedures.display_aequilibrae_formats_dialog.DisplayAequilibraEFormatsDialog.get_file_name"
+    mocker.patch(function, return_value=(None, None))
+
+    messagebar = ae.iface.messageBar()
+    assert messagebar.messages[1][-1] == "Error::Path provided is not a valid dataset", "Level 1 error message is missing"
+
+# @pytest.mark.skip("")
+def test_display_data_with_project(ae_with_project, mocker):
+    function = "qaequilibrae.modules.matrix_procedures.display_aequilibrae_formats_dialog.DisplayAequilibraEFormatsDialog.get_file_name"
+    mocker.patch(function, return_value=("test/data/SiouxFalls_project/matrices/demand.aem", "AEM"))
+
+    dialog = DisplayAequilibraEFormatsDialog(ae_with_project)
+
+    print(dialog.__dict__)

--- a/test/test_display_aequilibrae_formats.py
+++ b/test/test_display_aequilibrae_formats.py
@@ -13,7 +13,10 @@ def test_display_data_no_path(ae, mocker):
     dialog.close()
 
     messagebar = ae.iface.messageBar()
-    assert messagebar.messages[1][-1] == "Error::Path provided is not a valid dataset", "Level 1 error message is missing"
+    assert (
+        messagebar.messages[1][-1] == "Error::Path provided is not a valid dataset"
+    ), "Level 1 error message is missing"
+
 
 @pytest.mark.parametrize("has_project", [True, False])
 @pytest.mark.parametrize("file_name", ("demand.aem", "SiouxFalls.omx"))
@@ -24,7 +27,7 @@ def test_display_data_with_path(tmpdir, ae_with_project, mocker, has_project, fi
     mocker.patch(file_func, return_value=(file_path, extension.upper()))
 
     out_func = "qaequilibrae.modules.matrix_procedures.display_aequilibrae_formats_dialog.DisplayAequilibraEFormatsDialog.csv_file_path"
-    mocker.patch(out_func, return_value=f"{tmpdir}/{name}.csv",)
+    mocker.patch(out_func, return_value=f"{tmpdir}/{name}.csv")
 
     dialog = DisplayAequilibraEFormatsDialog(ae_with_project, file_path, has_project)
     dialog.export()

--- a/test/test_display_aequilibrae_formats.py
+++ b/test/test_display_aequilibrae_formats.py
@@ -1,22 +1,38 @@
+import os
+import numpy as np
 import pytest
+
 from qaequilibrae.modules.matrix_procedures.display_aequilibrae_formats_dialog import DisplayAequilibraEFormatsDialog
 
 
-# TODO:
-def test_display_data_without_project(ae, mocker):
-    dialog = DisplayAequilibraEFormatsDialog(ae)
-
+def test_display_data_no_path(ae, mocker):
     function = "qaequilibrae.modules.matrix_procedures.display_aequilibrae_formats_dialog.DisplayAequilibraEFormatsDialog.get_file_name"
     mocker.patch(function, return_value=(None, None))
+
+    dialog = DisplayAequilibraEFormatsDialog(ae)
+    dialog.close()
 
     messagebar = ae.iface.messageBar()
     assert messagebar.messages[1][-1] == "Error::Path provided is not a valid dataset", "Level 1 error message is missing"
 
-# @pytest.mark.skip("")
-def test_display_data_with_project(ae_with_project, mocker):
-    function = "qaequilibrae.modules.matrix_procedures.display_aequilibrae_formats_dialog.DisplayAequilibraEFormatsDialog.get_file_name"
-    mocker.patch(function, return_value=("test/data/SiouxFalls_project/matrices/demand.aem", "AEM"))
+@pytest.mark.parametrize("has_project", [True, False])
+@pytest.mark.parametrize("file_name", ("demand.aem", "SiouxFalls.omx"))
+def test_display_data_with_path(tmpdir, ae_with_project, mocker, has_project, file_name):
+    file_path = f"test/data/SiouxFalls_project/matrices/{file_name}"
+    name, extension = file_name.split(".")
+    file_func = "qaequilibrae.modules.matrix_procedures.display_aequilibrae_formats_dialog.DisplayAequilibraEFormatsDialog.get_file_name"
+    mocker.patch(file_func, return_value=(file_path, extension.upper()))
 
-    dialog = DisplayAequilibraEFormatsDialog(ae_with_project)
+    out_func = "qaequilibrae.modules.matrix_procedures.display_aequilibrae_formats_dialog.DisplayAequilibraEFormatsDialog.csv_file_path"
+    mocker.patch(out_func, return_value=f"{tmpdir}/{name}.csv",)
 
-    print(dialog.__dict__)
+    dialog = DisplayAequilibraEFormatsDialog(ae_with_project, file_path, has_project)
+    dialog.export()
+    dialog.exit_procedure()
+
+    assert dialog.error is None
+    assert np.sum(dialog.data_to_show.__dict__["matrix"]["matrix"]) == 360600
+    assert "matrix" in dialog.list_cores
+    assert "taz" in dialog.list_indices
+    assert dialog.data_type == extension.upper()
+    assert os.path.isfile(f"{tmpdir}/{name}.csv")

--- a/test/test_qaequilibrae_menu_without_project.py
+++ b/test/test_qaequilibrae_menu_without_project.py
@@ -106,14 +106,6 @@ def test_add_zoning_data_menu(ae, qtbot):
     assert messagebar.messages[3][-1] == "Error:You need to load a project first", "Level 3 error message is missing"
 
 
-def test_display_project_data_menu(ae, qtbot):
-    action = ae.menuActions["Data"][0]
-    assert action.text() == "Visualize data", "Wrong text content"
-    action.trigger()
-    messagebar = ae.iface.messageBar()
-    assert messagebar.messages[3][-1] == "Error:You need to load a project first", "Level 3 error message is missing"
-
-
 def test_import_matrices_menu(ae, qtbot):
     from qaequilibrae.modules.matrix_procedures import LoadMatrixDialog
 


### PR DESCRIPTION
This PR:

* Reorders tab displaying for _ui_project_data_
* Fixes the controls for _display_aequilibrae_formats_dialog.py_ for a situation in which the user closes the GetOutputFileName window. Before it raised an error and the _ui_vector_loader_ was not responsive. Now it still raises an error, but the UI is responsive, so the user can click once again to load the data or close the window. There is also a modification to allow the users to view the content of OMX, AEM or AED files using QAequilibraE without opening a project.
* Reflects these modifications in test files and other dialogs
* Adds test for LoadDatasetDialog class

