### PR TITLE
Remove link selection when plotting route choice results

### DIFF
--- a/qaequilibrae/modules/paths_procedures/plot_route_choice.py
+++ b/qaequilibrae/modules/paths_procedures/plot_route_choice.py
@@ -41,6 +41,7 @@ def plot_results(results, from_node, to_node, link_layer):
     temp_layer.renderer().symbol().deleteSymbolLayer(0)
     temp_layer.triggerRepaint()
 
+    link_layer.removeSelection()
     QgsProject.instance().addMapLayer(temp_layer)
 
 


### PR DESCRIPTION
In this PR we fix a bug when plotting route choice results for execute single.

We added a `removeSelection` argument to the link layer to avoid bad data visualization,