### PR TITLE
Version update

### DIFF
--- a/.github/workflows/DevWorkflow.yml
+++ b/.github/workflows/DevWorkflow.yml
@@ -27,6 +27,7 @@ jobs:
   unittest:
     needs: linting
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       max-parallel: 4
       matrix:

--- a/qaequilibrae/aequilibrae_version.txt
+++ b/qaequilibrae/aequilibrae_version.txt
@@ -1,1 +1,1 @@
-aequilibrae==1.1.5
+aequilibrae==1.3.0

--- a/qaequilibrae/metadata.txt
+++ b/qaequilibrae/metadata.txt
@@ -1,10 +1,10 @@
 [general]
 name=qaequilibrae
 qgisMinimumVersion=3.34.10
-qgisMaximumVersion=3.40.2
+qgisMaximumVersion=3.99.0
 description=Transportation modeling toolbox for QGIS
 about=QAequilibraE is the GUI for AequilibraE, a transportation modeling package designed to be an open-source alternative to traditional commercial packages. It is a comprehensive set of tools for modeling and visualization, including incredibly fast equilibrium traffic assignment, synthetic gravity models, network editing, and GTFS importer. http://www.aequilibrae.com/.
-version=1.2.0
+version=1.3.0
 author=Pedro Camargo
 email=pedro@outerloop.io
 repository= https://github.com/AequilibraE/QAequilibraE


### PR DESCRIPTION
In this PR we update the QAequilibraE version to 1.3.0 and the requirement for AequilibraE version 1.3.0 that will be released soon.

We also add a `timeout-minutes` parameter to the DevWorkflow to detect test failing before the threshold period of 6 hours.