### PR TITLE
Improve installation error messages

### DIFF
--- a/docs/source/_latex/index.rst
+++ b/docs/source/_latex/index.rst
@@ -10,3 +10,4 @@ QGIS
    ../getting_started
    ../menus_in_detail
    ../processing_provider
+   ../faqs

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -27,9 +27,7 @@ Installation
 
         # The downloader uses two files to mark when dependencies have need installed, we'll
         # remove those to get it to retry the downloads.
-        installer.remove_packages()
-
-        installer.install()
+        installer.retry_pkg_install()
 
 
 User issues

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -1,0 +1,44 @@
+Frequently Asked Questions (FAQs)
+=================================
+
+Installation
+------------
+.. admonition:: The installation fails when using a firewall
+
+    When operating behind a firewall, the pip dependency installation may fail and result in an
+    import error when next starting QGIS. One way to ensure the installation, is using the
+    ``DownloadAll`` class in a script, run in the Python terminal.
+
+    .. code::
+
+        # This script is to be executed in the QGIS Python console. Open it via the menu bar ->
+        # Plugins -> Python console, or use Ctrl + Alt + P. Then use the "Show Editor" button,
+        # paste this script, edit, and press execute. Pasting into the console directly will
+        # result in an exception.
+        import os
+        from qaequilibrae.download_extra_packages_class import DownloadAll
+
+        # Set the environment variables required for pip here
+        # os.environ["variable name"] = "variable value"
+
+        # Create an instance of the our downloader class, this handles all the dependencies that
+        # qaequilibrae needs and removes packages that conflict with the global QGIS packages.
+        installer = DownloadAll()
+
+        # The downloader uses two files to mark when dependencies have need installed, we'll
+        # remove those to get it to retry the downloads.
+        installer.remove_packages()
+
+        installer.install()
+
+
+User issues
+-----------
+.. admonition:: I've found a problem, how can I report it?
+
+    After reviewing the documentation and the discussions on our 
+    `Google Group <https://groups.google.com/g/aequilibrae>`_, and ensuring that 
+    there is an actual bug or documentation issue, you can report it in the following ways:
+
+    * Filing a bug report in the `issue tracker <https://github.com/AequilibraE/qaequilibrae/issues>`_;
+    * Creating a post in our `Google Group <https://groups.google.com/g/aequilibrae>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,11 +37,12 @@ QGIS
       Want to enhance your experience with AequilibraE? 
       Dive in our processing provider tools!
 
-   .. grid-item-card:: :material-outlined:`arrow_forward;1.5em` Want to go further?
-      :link: https://www.aequilibrae.com/latest/python/index.html
+   .. grid-item-card:: :material-outlined:`question_mark;1.5em` Frequently Asked Questions
+      :link: faqs
+      :link-type: any
       :text-align: center
-      
-      Explore our Python library!
+
+      Any problems? Check out our FAQs!
 
 .. toctree::
    :hidden:

--- a/qaequilibrae/download_extra_packages_class.py
+++ b/qaequilibrae/download_extra_packages_class.py
@@ -163,7 +163,7 @@ class DownloadAll:
                             f"Duplicated packages removed from installation: {fldr}", level=Qgis.MessageLevel.Info
                         )
 
-    def remove_packages(self):
+    def retry_pkg_install(self):
         existing_files = list(os.walk(self.target_folder))[0]
         for packages in existing_files[1]:
             shutil.rmtree(self.target_folder / packages)
@@ -172,6 +172,7 @@ class DownloadAll:
             if file == "__init__.py":
                 continue
             (self.target_folder / file).unlink()
+        self.install()
 
 
 if __name__ == "__main__":

--- a/qaequilibrae/download_extra_packages_class.py
+++ b/qaequilibrae/download_extra_packages_class.py
@@ -38,12 +38,12 @@ class DownloadAll:
         self.dependency_files = [pth / "requirements.txt", pth / "aequilibrae_version.txt"]
         self.target_folder = pth / "packages"
         self.no_ssl = False
+        self.error = 0
 
     def install(self):
-        reps = []
         command = f'"{self.find_python()}" -m pip install uv'
         _ = self.execute(command)
-        QgsMessageLog.logMessage(command, level=Qgis.MessageLevel.Info)
+        print(command)
 
         for file in self.dependency_files:
             flag = self.target_folder / file.name
@@ -54,13 +54,13 @@ class DownloadAll:
                 lines = fl.readlines()
 
             for line in lines:
-                reps.extend(self.install_package(line.strip()))
+                self.install_package(line.strip())
 
             with open(flag, "w") as fl:
                 fl.write("")
 
         self.clean_packages(self.target_folder)
-        return reps
+        return self.error
 
     def install_package(self, package):
         Path(self.target_folder).mkdir(parents=True, exist_ok=True)
@@ -71,18 +71,21 @@ class DownloadAll:
         install_command = f'-m {is_uv} pip install {package} --target "{self.target_folder}"'
 
         command = f'"{self.find_python()}" {install_command}'
-        QgsMessageLog.logMessage(command, level=Qgis.MessageLevel.Info)
+        print(command)
 
         if not self.no_ssl:
             reps = self.execute(command)
 
         if self.no_ssl or (
-            "because the SSL module is not available" in "".join(reps).lower() and sys.platform == "win32"
+            "because the ssl module is not available" in "".join(reps).lower() and sys.platform == "win32"
         ):
             command = f"python {install_command}"
-            QgsMessageLog.logMessage(command, level=Qgis.MessageLevel.Info)
+            print(command)
             reps = self.execute(command)
             self.no_ssl = True
+
+        for line in reps:
+            QgsMessageLog.logMessage(str(line), level=Qgis.MessageLevel.Info)
 
         return reps
 
@@ -97,10 +100,11 @@ class DownloadAll:
             stderr=subprocess.STDOUT,
             universal_newlines=True,
         )
-        for line in process.stdout:
-            QgsMessageLog.logMessage(line.strip(), level=Qgis.MessageLevel.Info)
+        lines.extend(process.stdout.readlines())
         exit_code = process.wait()
-        return exit_code
+        if exit_code != 0:
+            self.error = exit_code
+        return lines
 
     def find_python(self):
         # Check if we're inside a virtual environment
@@ -159,17 +163,17 @@ class DownloadAll:
                         )
 
     def remove_packages(self):
-        existing_files = list(os.walk(self.target_folder))
+        existing_files = list(os.walk(self.target_folder))[0]
         for packages in existing_files[1]:
             shutil.rmtree(self.target_folder / packages)
 
         for file in existing_files[2]:
             if file == "__init__.py":
                 continue
-            (self.target_folder / file.name).unlink()
+            (self.target_folder / file).unlink()
 
 
 if __name__ == "__main__":
     result = DownloadAll().install()
 
-    assert sum(result) == 0
+    assert result == 0

--- a/qaequilibrae/download_extra_packages_class.py
+++ b/qaequilibrae/download_extra_packages_class.py
@@ -43,7 +43,7 @@ class DownloadAll:
         reps = []
         command = f'"{self.find_python()}" -m pip install uv'
         _ = self.execute(command)
-        print(command)
+        QgsMessageLog.logMessage(command, level=Qgis.MessageLevel.Info)
 
         for file in self.dependency_files:
             flag = self.target_folder / file.name
@@ -71,36 +71,36 @@ class DownloadAll:
         install_command = f'-m {is_uv} pip install {package} --target "{self.target_folder}"'
 
         command = f'"{self.find_python()}" {install_command}'
-        print(command)
+        QgsMessageLog.logMessage(command, level=Qgis.MessageLevel.Info)
 
         if not self.no_ssl:
             reps = self.execute(command)
 
         if self.no_ssl or (
-            "because the ssl module is not available" in "".join(reps).lower() and sys.platform == "win32"
+            "because the SSL module is not available" in "".join(reps).lower() and sys.platform == "win32"
         ):
             command = f"python {install_command}"
-            print(command)
+            QgsMessageLog.logMessage(command, level=Qgis.MessageLevel.Info)
             reps = self.execute(command)
             self.no_ssl = True
 
-        for line in reps:
-            QgsMessageLog.logMessage(str(line))
         return reps
 
     def execute(self, command):
         lines = []
         lines.append(command)
-        with subprocess.Popen(
+        process = subprocess.Popen(
             command,
             shell=True,
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
-        ) as proc:
-            lines.extend(proc.stdout.readlines())
-        return lines
+        )
+        for line in process.stdout:
+            QgsMessageLog.logMessage(line.strip(), level=Qgis.MessageLevel.Info)
+        exit_code = process.wait()
+        return exit_code
 
     def find_python(self):
         # Check if we're inside a virtual environment
@@ -158,11 +158,18 @@ class DownloadAll:
                             f"Duplicated packages removed from installation: {fldr}", level=Qgis.MessageLevel.Info
                         )
 
+    def remove_packages(self):
+        existing_files = list(os.walk(self.target_folder))
+        for packages in existing_files[1]:
+            shutil.rmtree(self.target_folder / packages)
+
+        for file in existing_files[2]:
+            if file == "__init__.py":
+                continue
+            (self.target_folder / file.name).unlink()
+
 
 if __name__ == "__main__":
     result = DownloadAll().install()
-    output = "".join([str(x).upper() for x in result])
 
-    print(output)
-
-    assert "ERROR" not in output
+    assert sum(result) == 0

--- a/qaequilibrae/download_extra_packages_class.py
+++ b/qaequilibrae/download_extra_packages_class.py
@@ -60,6 +60,7 @@ class DownloadAll:
                 fl.write("")
 
         self.clean_packages(self.target_folder)
+        print("Error code: ", self.error)
         return self.error
 
     def install_package(self, package):

--- a/qaequilibrae/message.py
+++ b/qaequilibrae/message.py
@@ -16,7 +16,8 @@ class messages:
     def second_message(self):
         a = self.tr("Errors may have happened during installation.")
         b = self.tr("Please inspect the messages on your General Log message tab")
-        return f"{a}\r\n{b}"
+        c = self.tr("or go to the QAequilibraE FAQs and check for manual installation.")
+        return f"{a}\r\n{b}\r\n{c}"
 
     @property
     def third_message(self):

--- a/qaequilibrae/qaequilibrae.py
+++ b/qaequilibrae/qaequilibrae.py
@@ -48,7 +48,7 @@ else:
             from qaequilibrae.download_extra_packages_class import DownloadAll
 
             result = DownloadAll().install()
-            if sum(result) > 0:
+            if result > 0:
                 QMessageBox.information(None, "Information", msg.second_message)
             else:
                 QMessageBox.information(None, "Information", msg.third_message)

--- a/qaequilibrae/qaequilibrae.py
+++ b/qaequilibrae/qaequilibrae.py
@@ -48,7 +48,7 @@ else:
             from qaequilibrae.download_extra_packages_class import DownloadAll
 
             result = DownloadAll().install()
-            if "ERROR" in "".join([str(x).upper() for x in result]):
+            if sum(result) > 0:
                 QMessageBox.information(None, "Information", msg.second_message)
             else:
                 QMessageBox.information(None, "Information", msg.third_message)


### PR DESCRIPTION
In this PR we change the download extra packages class to handle installation errors, rather than only printing the installation log. We also changed the message when raising an error, and added a FAQ page to QAequilibraE docs to show the script.