### PR TITLE
Fixes path for exporting matrices

### DIFF
--- a/qaequilibrae/modules/matrix_procedures/display_aequilibrae_formats_dialog.py
+++ b/qaequilibrae/modules/matrix_procedures/display_aequilibrae_formats_dialog.py
@@ -437,7 +437,7 @@ class DisplayAequilibraEFormatsDialog(QtWidgets.QDialog, FORM_CLASS):
 
     def csv_file_path(self):
         new_name, _ = GetOutputFileName(
-            self, "Export matrix data", ["Comma-separated file(*.csv)"], ".csv", self.data_path
+            self, "Export matrix data", ["Comma-separated file(*.csv)"], ".csv", str(self.data_path)
         )
         return new_name
 


### PR DESCRIPTION
`self.data_path` was returning a `Path` object rather than a string, as required by QGIS. In this PR we fix this issue.