### PR TITLE
Fix PT dialogs against pandas 3 and aequilibrae 1.7.0

### DIFF
--- a/qaequilibrae/modules/common_tools/__init__.py
+++ b/qaequilibrae/modules/common_tools/__init__.py
@@ -1,5 +1,6 @@
 from .all_layers_from_toc import all_layers_from_toc
 from .auxiliary_functions import *
+from .auxiliary_functions import project_has_transit
 from .data_layer_from_dataframe import layer_from_dataframe
 from .data_layer_from_geodataframe import layer_from_geodataframe
 from .debouncer import Debouncer

--- a/qaequilibrae/modules/common_tools/auxiliary_functions.py
+++ b/qaequilibrae/modules/common_tools/auxiliary_functions.py
@@ -1,4 +1,5 @@
 import math
+from os.path import isfile
 from time import localtime, strftime
 from typing import Union
 
@@ -45,6 +46,19 @@ def get_vector_layer_by_name(layer_name):
         return None
     else:
         return layer[0]
+
+
+# AequilibraE builds an empty public_transport.sqlite whenever a project is opened, so the file
+# being on disk says nothing about whether there is a route system in it
+def project_has_transit(project) -> bool:
+    if not isfile(project._transit_database_path):
+        return False
+
+    with project.transit_connection as conn:
+        sql = "select name from sqlite_master where type='table' and name='routes'"
+        if conn.execute(sql).fetchone() is None:
+            return False
+        return conn.execute("select exists(select 1 from routes)").fetchone()[0] == 1
 
 
 # Haversine formula here:

--- a/qaequilibrae/modules/menu_actions/action_pt_explore.py
+++ b/qaequilibrae/modules/menu_actions/action_pt_explore.py
@@ -1,12 +1,12 @@
 def run_pt_explore(qgis_project):
     from qaequilibrae.modules.transit_procedures import TransitNavigatorDialog
-    from os.path import exists, join
+    from qaequilibrae.modules.common_tools import project_has_transit
 
     if qgis_project.project is None:
         qgis_project.show_message_no_project()
         return
 
-    elif not exists(qgis_project.project._transit_database_path):
+    elif not project_has_transit(qgis_project.project):
         qgis_project.message_no_gtfs_feed()
         return
 

--- a/qaequilibrae/modules/transit_procedures/gtfs_importer.py
+++ b/qaequilibrae/modules/transit_procedures/gtfs_importer.py
@@ -1,10 +1,10 @@
-from os.path import dirname, join, isfile
+from os.path import dirname, join
 
 from aequilibrae.transit import Transit
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QTableWidgetItem
 
-from qaequilibrae.modules.common_tools import BaseDialog
+from qaequilibrae.modules.common_tools import BaseDialog, project_has_transit
 from qaequilibrae.modules.transit_procedures import GTFSFeed
 
 
@@ -24,7 +24,7 @@ class GTFSImporter(BaseDialog):
         self.feeds = []
         self.done = 1
 
-        self.is_pt_database = isfile(self.qgis_project.project._transit_database_path)
+        self.is_pt_database = project_has_transit(self.qgis_project.project)
 
         if self.is_pt_database:
             self.rdo_clear.setText(self.tr("Overwrite Routes"))

--- a/qaequilibrae/modules/transit_procedures/transit_navigator_dialog.py
+++ b/qaequilibrae/modules/transit_procedures/transit_navigator_dialog.py
@@ -531,7 +531,10 @@ class TransitNavigatorDialog(BaseDialog):
         df = self.sm.zone_metrics(
             from_minute=from_time, to_minute=to_time, routes=routes, patterns=patterns, stops=stops
         )
-        df.loc[:, self.sm.list_zone_metrics()] /= sample
+        # Whole-column assignment, as the metrics come back as integers and expanding them by the
+        # sample rate makes them fractional. Pandas 3 refuses to write floats into an int column.
+        metrics = self.sm.list_zone_metrics()
+        df[metrics] = df[metrics] / sample
 
         self.zone_metric_layer = layer_from_dataframe(df, "zone_metrics")
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 qgis_qui_enabled=False
+# QgsApplication.exitQgis() destroys the QGIS C++ objects while Python still holds
+# wrappers for them, so the interpreter segfaults (exit 139) as soon as those are
+# garbage collected at shutdown. The process is exiting anyway, so skip the call.
+qgis_disable_exit=True
 filterwarnings = ignore::FutureWarning

--- a/test/requirements_test.txt
+++ b/test/requirements_test.txt
@@ -5,6 +5,6 @@ pytest-qt
 pytest-cov
 pytest-mock
 black==24.4.2
-ruff
+ruff==0.14.8
 pytest-reportlog
 pyarrow


### PR DESCRIPTION
map_zones divided int64 metric columns in place via df.loc. Pandas 2 upcast those to float with a FutureWarning; pandas 3 raises TypeError. Switched to whole-column assignment, which keeps the previous upcasting behaviour.

Since aequilibrae 1.7.0, Project.open() calls Transit(self) in __load_objects(), which copies a template public_transport.sqlite into every project. That made isfile(_transit_database_path) permanently true, so the GTFS importer offered 'Overwrite Routes' on projects with no feed, and 'Explore transit' skipped its guard and fell into TransitNavigatorDialog.exec_() instead of warning the user. Both now use project_has_transit(), which checks for rows in routes.

Also brings qgis_disable_exit=True across from claude/fix-pr-529-9e565e.