### PR TITLE
Add Create empty project tool to Model building

### DIFF
--- a/docs/source/processing_provider.rst
+++ b/docs/source/processing_provider.rst
@@ -236,6 +236,21 @@ the link IDs of the links you want to collapse separated by a comma.
     :align: center
     :alt: Processing provider collapse links
 
+.. _create_empty_project:
+
+Create empty project
+~~~~~~~~~~~~~~~~~~~~
+This tool creates a new AequilibraE project containing no links, nodes, or zones. The
+project is created with the default modes and link types, which are read from the
+:ref:`parameters file <parameters_file>`.
+
+The only input for the tool is the folder that will hold the new project. This folder
+must either not exist yet, or be empty.
+
+An empty project is the natural starting point when you intend to build your model
+incrementally with the other Model building tools, such as
+`Add links from layer to project`_ and `Add zoning data`_.
+
 .. _create_project_from_osm:
 
 Create project from OSM

--- a/docs/source/processing_provider.rst
+++ b/docs/source/processing_provider.rst
@@ -249,7 +249,7 @@ must either not exist yet, or be empty.
 
 An empty project is the natural starting point when you intend to build your model
 incrementally with the other Model building tools, such as
-`Add links from layer to project`_ and `Add zoning data`_.
+Add links from layer to project and :ref:`Add zoning data <add-zoning-data>`.
 
 .. _create_project_from_osm:
 

--- a/qaequilibrae/modules/processing_provider/model_building/create_empty_project.py
+++ b/qaequilibrae/modules/processing_provider/model_building/create_empty_project.py
@@ -1,0 +1,84 @@
+import importlib.util as iutil
+from os import listdir, rmdir
+from os.path import isdir
+
+from qgis.core import QgsProcessingAlgorithm, QgsProcessingException
+from qgis.core import QgsProcessingParameterFolderDestination
+
+from qaequilibrae.i18n.translate import trlt
+
+
+class CreateEmptyProject(QgsProcessingAlgorithm):
+
+    PROJECT_FOLDER = "PROJECT_FOLDER"
+
+    def initAlgorithm(self, config=None):
+        # Folder that will hold the brand new AequilibraE project
+        self.addParameter(
+            QgsProcessingParameterFolderDestination(self.PROJECT_FOLDER, self.tr("New AequilibraE project folder"))
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        project_folder = self.parameterAsString(parameters, self.PROJECT_FOLDER, context)
+
+        # Checks if we have access to AequilibraE library
+        if iutil.find_spec("aequilibrae") is None:
+            raise QgsProcessingException(self.tr("AequilibraE module not found"))
+
+        from aequilibrae.project import Project
+
+        # AequilibraE refuses to create a project on a folder that already exists, so we
+        # only clear the way when the folder we were pointed to is empty
+        if isdir(project_folder):
+            if listdir(project_folder):
+                raise QgsProcessingException(self.tr("Folder already exists and is not empty: ") + project_folder)
+            rmdir(project_folder)
+
+        feedback.pushInfo(self.tr("Creating project"))
+
+        project = Project()
+        try:
+            project.new(project_folder)
+        except Exception as e:
+            raise QgsProcessingException(self.tr("Could not create project: ") + str(e))
+
+        modes = list(project.network.modes.all_modes().keys())
+        link_types = list(project.network.link_types.all_types().keys())
+
+        project.close()
+
+        feedback.pushInfo(self.tr("Project created in ") + project_folder)
+        feedback.pushInfo(self.tr("Default modes: ") + ", ".join(sorted(modes)))
+        feedback.pushInfo(self.tr("Default link types: ") + ", ".join(sorted(link_types)))
+
+        return {"Output": project_folder}
+
+    def name(self):
+        return "create_empty_project"
+
+    def displayName(self) -> str:
+        return self.tr("Create empty project")
+
+    def group(self) -> str:
+        return self.tr("Model building")
+
+    def groupId(self) -> str:
+        return "model_building"
+
+    def shortHelpString(self):
+        help_messages = [
+            self.tr("Creates a new empty AequilibraE project, with no links, nodes or zones."),
+            self.tr("The project is created with the default modes and link types, and can be"),
+            self.tr("populated afterwards with the other Model building tools."),
+            self.tr("The folder you point to must not exist, or must be empty."),
+        ]
+        return "\n".join(help_messages)
+
+    def createInstance(self):
+        return CreateEmptyProject()
+
+    def tags(self):
+        return ["create", "new", "empty", "project", "model"]
+
+    def tr(self, message):
+        return trlt("CreateEmptyProject", message)

--- a/qaequilibrae/modules/processing_provider/model_building/create_empty_project.py
+++ b/qaequilibrae/modules/processing_provider/model_building/create_empty_project.py
@@ -32,8 +32,12 @@ class CreateEmptyProject(QgsProcessingAlgorithm):
         if isdir(project_folder):
             if listdir(project_folder):
                 raise QgsProcessingException(self.tr("Folder already exists and is not empty: ") + project_folder)
-            rmdir(project_folder)
-
+            try:
+                rmdir(project_folder)
+            except OSError as e:
+                raise QgsProcessingException(
+                    self.tr("Could not remove empty folder: ") + project_folder + f" ({e})"
+                ) from e
         feedback.pushInfo(self.tr("Creating project"))
 
         project = Project()

--- a/qaequilibrae/modules/processing_provider/provider.py
+++ b/qaequilibrae/modules/processing_provider/provider.py
@@ -51,6 +51,7 @@ class Provider(QgsProcessingProvider):
         from .model_building.add_links_from_layer import AddLinksFromLayer
         from .model_building.add_zones import AddZones
         from .model_building.collapse_links import CollapseLinks
+        from .model_building.create_empty_project import CreateEmptyProject
         from .model_building.network_simplifier import NetworkSimplifier
         from .model_building.network_preparation import PrepareNetwork
         from .model_building.project_from_layer import ProjectFromLayer
@@ -60,6 +61,7 @@ class Provider(QgsProcessingProvider):
         self.addAlgorithm(AddLinksFromLayer())
         self.addAlgorithm(AddZones())
         self.addAlgorithm(CollapseLinks())
+        self.addAlgorithm(CreateEmptyProject())
         self.addAlgorithm(NetworkSimplifier())
         self.addAlgorithm(PrepareNetwork())
         self.addAlgorithm(ProjectFromLayer())

--- a/test/test_processing_provider.py
+++ b/test/test_processing_provider.py
@@ -175,11 +175,11 @@ def test_create_empty_project(folder_path, pre_create_folder):
     parameters = {"PROJECT_FOLDER": folder_path}
 
     action = CreateEmptyProject()
+    action.initAlgorithm()
     context = QgsProcessingContext()
     feedback = QgsProcessingFeedback()
 
     results, ok = action.run(parameters, context, feedback)
-
     assert ok
     assert results["Output"] == folder_path
     assert isdir(folder_path)

--- a/test/test_processing_provider.py
+++ b/test/test_processing_provider.py
@@ -1,19 +1,20 @@
 import sys
 from os import makedirs
-from os.path import isfile, join
+from os.path import isdir, isfile, join
 
 import numpy as np
 import pytest
 from aequilibrae import Project
 from aequilibrae.matrix import AequilibraeMatrix
 from aequilibrae.utils.create_example import create_example
-from qgis.core import QgsApplication, QgsProcessingContext, QgsProcessingFeedback, QgsProject
+from qgis.core import QgsApplication, QgsProcessingContext, QgsProcessingException, QgsProcessingFeedback, QgsProject
 
 from qaequilibrae.modules.processing_provider.matrix_procedures.export_matrix import ExportMatrix
 from qaequilibrae.modules.processing_provider.matrix_procedures.matrix_calculator import MatrixCalculator
 from qaequilibrae.modules.processing_provider.matrix_procedures.trip_length_distribution import TripLengthDistribution
 from qaequilibrae.modules.processing_provider.model_building.add_links_from_layer import AddLinksFromLayer
 from qaequilibrae.modules.processing_provider.model_building.collapse_links import CollapseLinks
+from qaequilibrae.modules.processing_provider.model_building.create_empty_project import CreateEmptyProject
 from qaequilibrae.modules.processing_provider.model_building.network_simplifier import NetworkSimplifier
 from qaequilibrae.modules.processing_provider.provider import Provider
 from .utilities import load_test_layer
@@ -163,6 +164,50 @@ def test_collapse_links(folder_path):
 
     assert project.network.count_links() < links_before
     assert project.network.count_nodes() < nodes_before
+
+
+@pytest.mark.parametrize("pre_create_folder", [True, False])
+def test_create_empty_project(folder_path, pre_create_folder):
+    # QGIS may hand us an already existing (but empty) folder, so both cases must work
+    if pre_create_folder:
+        makedirs(folder_path)
+
+    parameters = {"PROJECT_FOLDER": folder_path}
+
+    action = CreateEmptyProject()
+    context = QgsProcessingContext()
+    feedback = QgsProcessingFeedback()
+
+    results, ok = action.run(parameters, context, feedback)
+
+    assert ok
+    assert results["Output"] == folder_path
+    assert isdir(folder_path)
+    assert isfile(join(folder_path, "project_database.sqlite"))
+
+    project = Project()
+    project.open(folder_path)
+
+    assert project.network.count_links() == 0
+    assert project.network.count_nodes() == 0
+    assert len(project.network.modes.all_modes()) > 0
+    assert len(project.network.link_types.all_types()) > 0
+
+    project.close()
+
+
+def test_create_empty_project_on_populated_folder(folder_path):
+    create_example(folder_path, "nauru").close()
+
+    parameters = {"PROJECT_FOLDER": folder_path}
+
+    action = CreateEmptyProject()
+    action.initAlgorithm()
+    context = QgsProcessingContext()
+    feedback = QgsProcessingFeedback()
+
+    with pytest.raises(QgsProcessingException):
+        action.processAlgorithm(parameters, context, feedback)
 
 
 def test_network_simplifier(folder_path):


### PR DESCRIPTION
Adds a processing algorithm that creates a new AequilibraE project with no links, nodes or zones, using the default modes and link types. Takes a folder destination, which must not exist or be empty, and reports the created project back as Output.