### PR TITLE
Fix crash opening a QGIS project saved with a scenario active

### DIFF
--- a/qaequilibrae/modules/menu_actions/load_project_action.py
+++ b/qaequilibrae/modules/menu_actions/load_project_action.py
@@ -17,12 +17,7 @@ def run_load_project(qgis_project):
 
 
 def _project_root(proj_path):
-    """Maps a scenario folder back to the project root it belongs to.
-
-    Scenarios live in ``<project root>/scenarios/<name>`` and their databases have no
-    ``scenarios`` table, so they cannot be opened as a project. QGIS projects saved while a
-    scenario was active stored that folder instead of the project root, so we walk back up.
-    """
+    """Maps a scenario folder back to the project root it belongs to"""
     path = Path(proj_path)
     if path.parent.name == "scenarios" and (path.parent.parent / "project_database.sqlite").is_file():
         return str(path.parent.parent)

--- a/qaequilibrae/modules/menu_actions/load_project_action.py
+++ b/qaequilibrae/modules/menu_actions/load_project_action.py
@@ -16,6 +16,19 @@ def run_load_project(qgis_project):
     return _run_load_project_from_path(qgis_project, proj_path)
 
 
+def _project_root(proj_path):
+    """Maps a scenario folder back to the project root it belongs to.
+
+    Scenarios live in ``<project root>/scenarios/<name>`` and their databases have no
+    ``scenarios`` table, so they cannot be opened as a project. QGIS projects saved while a
+    scenario was active stored that folder instead of the project root, so we walk back up.
+    """
+    path = Path(proj_path)
+    if path.parent.name == "scenarios" and (path.parent.parent / "project_database.sqlite").is_file():
+        return str(path.parent.parent)
+    return proj_path
+
+
 def _run_load_project_from_path(qgis_project, proj_path):
     from aequilibrae.project import Project
     from aequilibrae.project.tools import MigrationManager
@@ -23,6 +36,8 @@ def _run_load_project_from_path(qgis_project, proj_path):
 
     if proj_path is None or proj_path == "":
         return
+
+    proj_path = _project_root(proj_path)
 
     if proj_path is not None and len(proj_path) > 0:
         qgis_project.contents = []

--- a/qaequilibrae/qaequilibrae.py
+++ b/qaequilibrae/qaequilibrae.py
@@ -374,8 +374,6 @@ class AequilibraEMenu:
             # Open AequilibraE project
             _run_load_project_from_path(self, path["aequilibrae_path"])
 
-            # Go back to last scenario. It may be gone by now, and failing here would abort
-            # the opening of the QGIS project itself, so we just stay on the root scenario.
             scenario = path.get("aeq_scenario")
             if scenario and scenario in self.available_scenarios:
                 self.cob_scenarios.setCurrentText(scenario)
@@ -407,8 +405,6 @@ class AequilibraEMenu:
         qgis.utils.iface.mapCanvas().refresh()
 
     def _project_base_path(self):
-        # project_base_path follows the active scenario into <project root>/scenarios/<name>, but the
-        # layer database and the path we store in the QGIS project must always be the project root.
         return self.project.root_scenario.base_path
 
     def _project_layers_database(self):

--- a/qaequilibrae/qaequilibrae.py
+++ b/qaequilibrae/qaequilibrae.py
@@ -374,10 +374,14 @@ class AequilibraEMenu:
             # Open AequilibraE project
             _run_load_project_from_path(self, path["aequilibrae_path"])
 
-            # Go back to last scenario
-            if "aeq_scenario" in path:
-                self.cob_scenarios.setCurrentText(path["aeq_scenario"])
-                self.project.use_scenario(path["aeq_scenario"])
+            # Go back to last scenario. It may be gone by now, and failing here would abort
+            # the opening of the QGIS project itself, so we just stay on the root scenario.
+            scenario = path.get("aeq_scenario")
+            if scenario and scenario in self.available_scenarios:
+                self.cob_scenarios.setCurrentText(scenario)
+                self.project.use_scenario(scenario)
+            elif scenario:
+                self.message_log(self.tr("Scenario '{}' no longer exists. Using 'root'.").format(scenario))
         else:
             return
 
@@ -403,9 +407,9 @@ class AequilibraEMenu:
         qgis.utils.iface.mapCanvas().refresh()
 
     def _project_base_path(self):
-        if "/scenarios/" in str(self.project.project_base_path):
-            return self.project.project_base_path.parent.parent
-        return self.project.project_base_path
+        # project_base_path follows the active scenario into <project root>/scenarios/<name>, but the
+        # layer database and the path we store in the QGIS project must always be the project root.
+        return self.project.root_scenario.base_path
 
     def _project_layers_database(self):
         return str(self._project_base_path() / "qgis_layers.sqlite")

--- a/test/test_scenario_project_path.py
+++ b/test/test_scenario_project_path.py
@@ -4,11 +4,6 @@ from qaequilibrae.modules.menu_actions.load_project_action import _project_root,
 
 
 def test_base_path_is_root_while_scenario_is_active(sf_project):
-    """The path saved into the QGIS project must be the project root, never the scenario folder.
-
-    ``project_base_path`` follows the active scenario, and storing that folder made QGIS try to
-    reopen a scenario database - which has no ``scenarios`` table - on the next project load.
-    """
     root = Path(sf_project.project.project_base_path)
 
     sf_project.project.clone_scenario("a_scenario", "Scenario for test")

--- a/test/test_scenario_project_path.py
+++ b/test/test_scenario_project_path.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from qaequilibrae.modules.menu_actions.load_project_action import _project_root, _run_load_project_from_path
+
+
+def test_base_path_is_root_while_scenario_is_active(sf_project):
+    """The path saved into the QGIS project must be the project root, never the scenario folder.
+
+    ``project_base_path`` follows the active scenario, and storing that folder made QGIS try to
+    reopen a scenario database - which has no ``scenarios`` table - on the next project load.
+    """
+    root = Path(sf_project.project.project_base_path)
+
+    sf_project.project.clone_scenario("a_scenario", "Scenario for test")
+    sf_project.project.use_scenario("a_scenario")
+
+    assert Path(sf_project.project.project_base_path) == root / "scenarios" / "a_scenario"
+    assert Path(sf_project._project_base_path()) == root
+    assert Path(sf_project._project_layers_database()) == root / "qgis_layers.sqlite"
+
+    sf_project.project.use_scenario("root")
+
+
+def test_project_root_maps_scenario_folder_back(sf_project, tmp_path):
+    root = Path(sf_project.project.project_base_path)
+    sf_project.project.clone_scenario("a_scenario", "Scenario for test")
+
+    assert _project_root(str(root / "scenarios" / "a_scenario")) == str(root)
+    assert _project_root(str(root)) == str(root)
+
+    # A folder that merely sits under a directory called "scenarios" is left alone
+    stray = tmp_path / "scenarios" / "not_a_scenario"
+    stray.mkdir(parents=True)
+    assert _project_root(str(stray)) == str(stray)
+
+
+def test_load_project_from_scenario_folder(qgis_iface, sf_project):
+    """QGIS projects saved before the fix stored the scenario folder, and must still open."""
+    from qaequilibrae.qaequilibrae import AequilibraEMenu
+
+    root = Path(sf_project.project.project_base_path)
+    sf_project.project.clone_scenario("a_scenario", "Scenario for test")
+
+    ae = AequilibraEMenu(qgis_iface)
+    try:
+        _run_load_project_from_path(ae, str(root / "scenarios" / "a_scenario"))
+
+        assert Path(ae.project.project_base_path) == root
+        assert ae.available_scenarios == ["root", "a_scenario"]
+    finally:
+        ae.run_close_project()


### PR DESCRIPTION
_project_base_path tested for '/scenarios/' in a str(Path), which never matches on Windows, so the active scenario folder was stored as aequilibrae_path. Reopening then tried to open a scenario database as a project and failed on the missing scenarios table. Use root_scenario.base_path instead, map already-saved scenario paths back to the project root on load, and skip a stale scenario rather than aborting the QGIS project open.