### PR TITLE
Creating model from layer

### DIFF
--- a/.github/workflows/DevWorkflow.yml
+++ b/.github/workflows/DevWorkflow.yml
@@ -50,4 +50,4 @@ jobs:
           . /tmp/.venv/bin/activate
           export QT_QPA_PLATFORM=offscreen
           pwd
-          python3 -m pytest test/test_comp*
+          python3 -m pytest --cov-report term-missing --cov=qaequilibrae test

--- a/docs/source/processing_provider.rst
+++ b/docs/source/processing_provider.rst
@@ -308,7 +308,7 @@ required field for the conversion:
 The *link_id* field can also be brought from the layer, but QAequilibraE
 numbers the links for you if you would rather not provide it.
 
-The *a_node*, *b_node* and *length* fields cannot be brought from the layer, as
+The *a_node*, *b_node* and *distance* fields cannot be brought from the layer, as
 AequilibraE computes them from the link geometry and the nodes layer.
 
 These requirements often create quite a bit of manual work, as most networks

--- a/docs/source/processing_provider.rst
+++ b/docs/source/processing_provider.rst
@@ -301,14 +301,15 @@ The AequilibraE project can also be bootstrapped from existing line and node
 layers obtained from any other source, as long as they contain the following
 required field for the conversion:
 
-* link_id
-* a_node
-* b_node
 * link direction
-* length
-* speed
 * allowed modes
 * link type
+
+The *link_id* field can also be brought from the layer, but QAequilibraE
+numbers the links for you if you would rather not provide it.
+
+The *a_node*, *b_node* and *length* fields cannot be brought from the layer, as
+AequilibraE computes them from the link geometry and the nodes layer.
 
 These requirements often create quite a bit of manual work, as most networks
 available do not have complete (or reliable) information. Manually editing the
@@ -328,15 +329,22 @@ presented with the following screen.
     :align: center
     :alt: project_from_layers_links
 
-The first 7 fields for links are mandatory, and one needs to associate the
-corresponding layer fields to the network fields.
+The list on the right side of the screen holds the fields of the standard
+AequilibraE link layer: *link_id*, *direction*, *modes*, *link_type*, *name*,
+*speed_ab/ba*, *travel_time_ab/ba* and *capacity_ab/ba*.
 
-The other fields that will be listed on the left side come from the parameters
-file (see the manual for that portion for more details), but the user can add
-more fields from the layer, as all of them are listed on the left side of the
-screen
+The fields AequilibraE requires are taken from the layer, and one needs to
+associate the corresponding layer field to each of them. The remaining ones start
+out with *Initialize?* checked, which leaves them empty in the new project —
+uncheck the box to bring one of them from the layer instead. *link_id* is the only
+required field whose box you can check, in which case QAequilibraE numbers the
+links sequentially for you.
 
-In the case of the nodes layer, only two fields are mandatory.
+Any other field is up to the user to bring from the layer being imported. All the
+layer fields are listed on the left side of the screen, and the ones added to the
+list on the right are created in the project with the same name.
+
+In the case of the nodes layer, both fields are mandatory.
 
 .. image:: images/processing_provider/project_from_layers_nodes.png
     :width: 614

--- a/qaequilibrae/modules/project_procedures/creates_transponet_dialog.py
+++ b/qaequilibrae/modules/project_procedures/creates_transponet_dialog.py
@@ -5,7 +5,6 @@ from os.path import dirname, isdir, join
 import qgis
 from PyQt5.QtCore import Qt
 from aequilibrae.context import get_logger
-from aequilibrae.parameters import Parameters
 from aequilibrae.project.network.network import Network
 from qgis.PyQt import QtWidgets, uic
 from qgis.PyQt.QtWidgets import QWidget, QFileDialog
@@ -19,6 +18,19 @@ from qaequilibrae.modules.project_procedures.creates_transponet_procedure import
 sys.modules["qgsmaplayercombobox"] = qgis.gui
 FORM_CLASS, _ = uic.loadUiType(join(dirname(__file__), "forms/ui_transponet_construction.ui"))
 
+# Fields of the standard AequilibraE link and node layers. Any other field is up to the user to bring from
+# the layer being imported
+extra_link_fields = ["name", "speed_ab", "speed_ba", "travel_time_ab", "travel_time_ba", "capacity_ab", "capacity_ba"]
+standard_link_fields = Network.req_link_flds + extra_link_fields
+standard_node_fields = Network.req_node_flds + ["modes", "link_types"]
+
+# Fields computed by the project's triggers, so they can never be brought from the layer
+computed_link_fields = ["a_node", "b_node", "distance"]
+computed_node_fields = ["modes", "link_types"]
+
+# Fields AequilibraE requires, but that QAequilibraE can populate on its own
+initializable_link_fields = ["link_id"]
+
 
 class CreatesTranspoNetDialog(QtWidgets.QDialog, FORM_CLASS):
     def __init__(self, qgis_project):
@@ -31,9 +43,14 @@ class CreatesTranspoNetDialog(QtWidgets.QDialog, FORM_CLASS):
         self.missing_data = -1
         self.path = standard_path()
 
-        self.required_fields_links = Network.req_link_flds
+        # We list the standard layers, minus whatever the project computes on its own
+        self.standard_fields_links = [fld for fld in standard_link_fields if fld not in computed_link_fields]
+        self.standard_fields_nodes = [fld for fld in standard_node_fields if fld not in computed_node_fields]
 
-        self.required_fields_nodes = Network.req_node_flds
+        # The fields AequilibraE requires are taken from the layer. The remaining standard ones start out
+        # initialized, as most layers being imported will not have them
+        self.from_layer_links = [fld for fld in Network.req_link_flds if fld not in computed_link_fields]
+        self.from_layer_nodes = [fld for fld in Network.req_node_flds if fld not in computed_node_fields]
 
         self.link_layer = False
         self.node_layer = False
@@ -84,19 +101,19 @@ class CreatesTranspoNetDialog(QtWidgets.QDialog, FORM_CLASS):
         self.but_removes_from_nodes.clicked.connect(partial(self.removes_fields, "nodes"))
 
     def removes_fields(self, layer_type):
-        layer_fields, table, final_table, required_fields = self.__find_layer_changed(layer_type)
+        layer_fields, table, final_table, standard_fields = self.__find_layer_changed(layer_type)
 
         for i in final_table.selectedRanges():
             old_fields = [final_table.item(row, 0).text() for row in range(i.topRow(), i.bottomRow() + 1)]
 
             for row in range(i.bottomRow(), i.topRow() - 1, -1):
-                if final_table.item(row, 0).text() in required_fields:
+                if final_table.item(row, 0).text() in standard_fields:
                     break
                 final_table.removeRow(row)
 
             counter = table.rowCount()
             for field in old_fields:
-                if field not in required_fields:
+                if field not in standard_fields:
                     table.setRowCount(counter + 1)
                     item1 = QtWidgets.QTableWidgetItem(field)
                     item1.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
@@ -104,7 +121,7 @@ class CreatesTranspoNetDialog(QtWidgets.QDialog, FORM_CLASS):
                     counter += 1
 
     def append_to_list(self, layer_type):
-        layer_fields, table, final_table, required_fields = self.__find_layer_changed(layer_type)
+        layer_fields, table, final_table, standard_fields = self.__find_layer_changed(layer_type)
         for i in table.selectedRanges():
             new_fields = [table.item(row, 0).text() for row in range(i.topRow(), i.bottomRow() + 1)]
 
@@ -135,10 +152,6 @@ class CreatesTranspoNetDialog(QtWidgets.QDialog, FORM_CLASS):
 
     def __find_layer_changed(self, layer_type):
         layer_fields = None
-        p = Parameters()
-
-        def fkey(f):
-            return list(f.keys())[0]
 
         if layer_type == "nodes":
             table = self.table_available_node_field
@@ -146,42 +159,26 @@ class CreatesTranspoNetDialog(QtWidgets.QDialog, FORM_CLASS):
             # TODO : Change for the method .currentlayer()
             # Repeat the change throughout
             self.node_layer = get_vector_layer_by_name(self.node_layers_list.currentText())
-            required_fields = self.required_fields_nodes
-            if self.node_layer:
-                layer_fields = self.node_layer.fields()
-                layer_fields = [f for f in layer_fields if f.name().lower() not in Network.protected_fields]
-
-            flds = p.parameters["network"]["nodes"]["fields"]
-            ndflds = [f"{fkey(f)}" for f in flds if fkey(f).lower() not in Network.req_node_flds]
-            required_fields.extend(ndflds)
+            standard_fields = self.standard_fields_nodes
+            unavailable_fields = Network.protected_fields + computed_node_fields
+            layer = self.node_layer
 
         if layer_type == "links":
             table = self.table_available_link_fields
             final_table = self.table_link_fields
             self.link_layer = get_vector_layer_by_name(self.link_layers_list.currentText())
-            required_fields = self.required_fields_links
+            standard_fields = self.standard_fields_links
+            unavailable_fields = Network.protected_fields + computed_link_fields
+            layer = self.link_layer
 
-            fields = p.parameters["network"]["links"]["fields"]
-            flds = fields["one-way"]
+        if layer:
+            layer_fields = [f for f in layer.fields() if f.name().lower() not in unavailable_fields]
 
-            owlf = [f"{fkey(f)}" for f in flds if fkey(f).lower() not in Network.req_link_flds]
-
-            flds = fields["two-way"]
-            twlf = []
-            for f in flds:
-                twlf.extend([f"{fkey(f)}_ab", f"{fkey(f)}_ba"])
-
-            required_fields = required_fields + owlf + twlf
-
-            if self.link_layer:
-                layer_fields = self.link_layer.fields()
-                layer_fields = [f for f in layer_fields if f.name().lower() not in Network.protected_fields]
-
-        return layer_fields, table, final_table, required_fields
+        return layer_fields, table, final_table, standard_fields
 
     def changed_layer(self, layer_type):
         try:
-            layer_fields, table, final_table, required_fields = self.__find_layer_changed(layer_type)
+            layer_fields, table, final_table, standard_fields = self.__find_layer_changed(layer_type)
             table.clearContents()
             table.setRowCount(0)
             # We create the comboboxes that will hold the definitions for all the fields that are mandatory for
@@ -202,27 +199,30 @@ class CreatesTranspoNetDialog(QtWidgets.QDialog, FORM_CLASS):
 
             counter = 0
             if layer_type == "links":
-                init_fields = [x for x in required_fields if x not in Network.req_link_flds]
+                from_layer, can_initialize = self.from_layer_links, initializable_link_fields
             else:
-                init_fields = [x for x in required_fields if x not in Network.req_node_flds]
+                from_layer, can_initialize = self.from_layer_nodes, []
 
-            for rf in required_fields:
+            for rf in standard_fields:
                 final_table.setRowCount(counter + 1)
 
                 item1 = QtWidgets.QTableWidgetItem(rf)
                 item1.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
                 final_table.setItem(counter, 0, item1)
 
+                # The fields AequilibraE requires come from the layer and cannot be switched off, unless we
+                # are able to initialize them ourselves. All the other ones start out initialized
                 chb1 = QtWidgets.QCheckBox()
-                if rf in init_fields:
-                    chb1.setChecked(True)
-                    chb1.stateChanged.connect(partial(self.set_field_to_default, layer_type))
-                else:
-                    chb1.setChecked(True)
-                    chb1.stateChanged.connect(partial(self.set_field_to_default, layer_type))
-                    chb1.setChecked(False)
-                    chb1.setEnabled(False)
+                chb1.setChecked(rf not in from_layer)
+                chb1.setEnabled(rf not in from_layer or rf in can_initialize)
+                chb1.stateChanged.connect(partial(self.set_field_to_default, layer_type))
                 final_table.setCellWidget(counter, 1, self.centers_item(chb1))
+
+                if rf in from_layer and layer_fields is not None:
+                    cbb = QtWidgets.QComboBox()
+                    for field in layer_fields:
+                        cbb.addItem(field.name())
+                    final_table.setCellWidget(counter, 2, self.centers_item(cbb))
                 counter += 1
         except Exception as e:
             self.logger.error(e.args)
@@ -237,7 +237,7 @@ class CreatesTranspoNetDialog(QtWidgets.QDialog, FORM_CLASS):
         return cell_widget
 
     def set_field_to_default(self, layer_type):
-        layer_fields, table, final_table, required_fields = self.__find_layer_changed(layer_type)
+        layer_fields, table, final_table, standard_fields = self.__find_layer_changed(layer_type)
 
         if layer_fields is not None:
             ch_box = self.sender()

--- a/qaequilibrae/modules/project_procedures/creates_transponet_procedure.py
+++ b/qaequilibrae/modules/project_procedures/creates_transponet_procedure.py
@@ -54,7 +54,7 @@ class CreatesTranspoNetProcedure(WorkerThread):
         existing_fields = data.data.columns.tolist()
 
         for f in set(layer_fields.keys()):
-            if f.lower() in existing_fields:
+            if f.lower() in existing_fields or layer_fields[f] < 0:
                 continue
             field = fields[layer_fields[f]]
             if not field.isNumeric():
@@ -82,7 +82,7 @@ class CreatesTranspoNetProcedure(WorkerThread):
         gdf = gdf.sjoin(nodes)
         gdf.drop(columns={"geometry", "index_right"}, inplace=True)
 
-        flds = list(self.node_fields.keys())
+        flds = [fld for fld, idx in self.node_fields.items() if idx >= 0]
         setting = [f"{fld}=?" for fld in flds if fld != "node_id"]
         sql_values = f'UPDATE nodes SET {",".join(setting)} WHERE node_id=?;'
 
@@ -93,7 +93,7 @@ class CreatesTranspoNetProcedure(WorkerThread):
             conn.executemany(sql_id, gdf.iloc[:, :1].join(gdf.iloc[:, -1:]).to_records(index=False))
 
     def transfer_layer_features(self, table, layer, layer_fields):
-        # We ensure that `link_id`, `a_node`, `b_node`, and `direction` fields are always integers
+        # We ensure that `link_id` and `direction` fields are always integers
         gdf = geodataframe_from_layer(layer).infer_objects()
 
         all_modes = set("".join(gdf.iloc[:, layer_fields["modes"]].unique()))
@@ -102,11 +102,25 @@ class CreatesTranspoNetProcedure(WorkerThread):
 
         crs = int(layer.crs().authid().split(":")[1])
         fields = [k for k, v in layer_fields.items() if v >= 0]
-        field_titles = ",".join(fields)
-        sql = f"""INSERT INTO {table} ({field_titles},geometry)
-                  VALUES ({','.join(['?'] * len(fields))},GeomFromWKB(?, {crs}))"""
-
         columns = [gdf.columns.tolist()[idx] for idx in layer_fields.values() if idx >= 0]
+
+        # `link_id` does not need to come from the layer, in which case we number the links sequentially
+        if layer_fields.get("link_id", -1) < 0:
+            gdf = gdf.assign(__aeq_link_id__=np.arange(1, gdf.shape[0] + 1))
+            fields.insert(0, "link_id")
+            columns.insert(0, "__aeq_link_id__")
+
+        # `a_node` and `b_node` are computed by the database triggers from the link geometry, but the links
+        # table only accepts them as integers, so we seed them the same way AequilibraE itself does
+        markers = ["?"] * len(fields)
+        for fld in ["a_node", "b_node"]:
+            if fld not in fields:
+                fields.append(fld)
+                markers.append("0")
+
+        sql = f"""INSERT INTO {table} ({",".join(fields)},geometry)
+                  VALUES ({",".join(markers)},GeomFromWKB(?, {crs}))"""
+
         columns.extend(["geoms"])
 
         gdf = gdf[columns]

--- a/test/test_create_transponet.py
+++ b/test/test_create_transponet.py
@@ -12,6 +12,70 @@ from .utilities import load_test_layer
 
 pytestmark = pytest.mark.skipif(sys.platform.startswith("win"), reason="Running on Windows")
 
+# The standard AequilibraE link layer, minus a_node/b_node/distance, which the project computes on its own
+link_standard_fields = ["link_id", "direction", "modes", "link_type", "name", "speed_ab", "speed_ba",
+                        "travel_time_ab", "travel_time_ba", "capacity_ab", "capacity_ba"]  # fmt: skip
+node_standard_fields = ["node_id", "is_centroid"]
+
+# The ones AequilibraE requires, which are the only ones taken from the layer by default
+link_fields_from_layer = ["link_id", "direction", "modes", "link_type"]
+
+
+def fields_in_table(table):
+    return [table.item(row, 0).text() for row in range(table.rowCount())]
+
+
+def checkbox_for(table, field):
+    row = fields_in_table(table).index(field)
+    return table.cellWidget(row, 1).findChildren(QtWidgets.QCheckBox)[0]
+
+
+def set_source_field(table, field, source):
+    row = fields_in_table(table).index(field)
+    combobox = table.cellWidget(row, 2).findChildren(QtWidgets.QComboBox)[0]
+    combobox.setCurrentIndex(combobox.findText(source))
+
+
+def map_standard_fields(dialog):
+    for field in link_fields_from_layer:
+        set_source_field(dialog.table_link_fields, field, field)
+
+    for field in node_standard_fields:
+        set_source_field(dialog.table_node_fields, field, field)
+
+
+def test_dialog_only_offers_standard_fields(ae, folder_path):
+    load_test_layer(folder_path, "node")
+    load_test_layer(folder_path, "link")
+
+    dialog = CreatesTranspoNetDialog(ae)
+
+    assert fields_in_table(dialog.table_link_fields) == link_standard_fields
+    assert fields_in_table(dialog.table_node_fields) == node_standard_fields
+
+    # Fields computed by the project's triggers cannot be brought from the layer
+    for field in ["a_node", "b_node", "distance"]:
+        assert field not in fields_in_table(dialog.table_available_link_fields)
+
+    # Any other field from the layer is up to the user to bring in
+    for field in ["matrix_ab", "matrix_ba", "matrix_tot"]:
+        assert field in fields_in_table(dialog.table_available_link_fields)
+
+    # The fields AequilibraE requires come from the layer, and only link_id can be initialized instead
+    assert checkbox_for(dialog.table_link_fields, "link_id").isEnabled()
+    for field in ["direction", "modes", "link_type"]:
+        assert not checkbox_for(dialog.table_link_fields, field).isEnabled()
+    for field in node_standard_fields:
+        assert not checkbox_for(dialog.table_node_fields, field).isEnabled()
+
+    for field in link_fields_from_layer:
+        assert not checkbox_for(dialog.table_link_fields, field).isChecked()
+
+    # The remaining standard fields start out initialized, but the user can bring them from the layer
+    for field in ["name", "speed_ab", "travel_time_ba", "capacity_ab"]:
+        assert checkbox_for(dialog.table_link_fields, field).isChecked()
+        assert checkbox_for(dialog.table_link_fields, field).isEnabled()
+
 
 def test_dialog(ae, folder_path):
     load_test_layer(folder_path, "node")
@@ -20,40 +84,11 @@ def test_dialog(ae, folder_path):
     dialog = CreatesTranspoNetDialog(ae)
     dialog.project_destination.setText(folder_path)
 
-    links_columns = [
-        "link_id",
-        "a_node",
-        "b_node",
-        "direction",
-        "distance",
-        "modes",
-        "link_type",
-        "link_id",
-        "a_node",
-        "b_node",
-        "direction",
-        "distance",
-        "modes",
-        "link_type",
-    ]
-    nodes_columns = ["node_id", "is_centroid", "node_id", "is_centroid"]
+    map_standard_fields(dialog)
 
-    child = dialog.findChildren(QtWidgets.QComboBox)
-    links_chd = []
-    nodes_chd = []
-    for chd in child:
-        if chd.count() == 11:
-            links_chd.append(chd)
-        elif chd.count() == 4:
-            nodes_chd.append(chd)
-
-    for idx, chd in enumerate(links_chd):
-        i = chd.findText(links_columns[idx])
-        chd.setCurrentIndex(i)
-
-    for idx, chd in enumerate(nodes_chd):
-        i = chd.findText(nodes_columns[idx])
-        chd.setCurrentIndex(i)
+    # A standard field that starts out initialized can still be brought from the layer
+    checkbox_for(dialog.table_link_fields, "name").setChecked(False)
+    set_source_field(dialog.table_link_fields, "name", "name")
 
     dialog.create_net()
 
@@ -63,6 +98,11 @@ def test_dialog(ae, folder_path):
 
     project_links = project.network.links.data
     assert project_links.shape[0] == 5
+    assert sorted(project_links["link_id"].tolist()) == [1, 2, 3, 4, 5]
+    assert "fifth link" in project_links["name"].tolist()
+
+    # Standard fields left initialized are simply empty
+    assert project_links["speed_ab"].isna().all()
 
     project_nodes = project.network.nodes.data
     assert project_nodes.shape[0] == 4
@@ -76,6 +116,54 @@ def test_dialog(ae, folder_path):
         assert mode in modes.all_modes().keys()
 
 
+def test_dialog_bringing_extra_field_from_layer(ae, folder_path):
+    load_test_layer(folder_path, "node")
+    load_test_layer(folder_path, "link")
+
+    dialog = CreatesTranspoNetDialog(ae)
+    dialog.project_destination.setText(folder_path)
+
+    map_standard_fields(dialog)
+
+    # Fields that are not part of the standard layer are brought from the layer by the user
+    available = dialog.table_available_link_fields
+    available.selectRow(fields_in_table(available).index("matrix_ab"))
+    dialog.but_adds_to_links.click()
+
+    assert "matrix_ab" in fields_in_table(dialog.table_link_fields)
+
+    dialog.create_net()
+
+    project = Project()
+    project.open(dialog.worker_thread.proj_folder)
+
+    project_links = project.network.links.data
+    assert sorted(project_links["matrix_ab"].tolist()) == [17, 19, 32, 42, 50]
+
+
+def test_dialog_initializing_link_id(ae, folder_path):
+    load_test_layer(folder_path, "node")
+    load_test_layer(folder_path, "link")
+
+    dialog = CreatesTranspoNetDialog(ae)
+    dialog.project_destination.setText(folder_path)
+
+    map_standard_fields(dialog)
+
+    # We let QAequilibraE number the links for us
+    checkbox_for(dialog.table_link_fields, "link_id").setChecked(True)
+
+    dialog.create_net()
+
+    assert dialog.link_fields["link_id"] == -1
+
+    project = Project()
+    project.open(dialog.worker_thread.proj_folder)
+
+    project_links = project.network.links.data
+    assert sorted(project_links["link_id"].tolist()) == [1, 2, 3, 4, 5]
+
+
 def test_procedure(ae, folder_path):
     load_test_layer(folder_path, "node")
     load_test_layer(folder_path, "link")
@@ -83,28 +171,7 @@ def test_procedure(ae, folder_path):
     nodes = QgsProject.instance().mapLayersByName("node")[0]
     links = QgsProject.instance().mapLayersByName("link")[0]
 
-    links_fields = {
-        "link_id": 7,
-        "a_node": 0,
-        "b_node": 1,
-        "direction": 2,
-        "distance": 3,
-        "modes": 4,
-        "link_type": 5,
-        "name": -1,
-        "cycleway": -1,
-        "cycleway_right": -1,
-        "cycleway_left": -1,
-        "busway": -1,
-        "busway_right": -1,
-        "busway_left": -1,
-        "lanes_ab": -1,
-        "lanes_ba": -1,
-        "capacity_ab": -1,
-        "capacity_ba": -1,
-        "speed_ab": -1,
-        "speed_ba": -1,
-    }
+    links_fields = {"link_id": 7, "direction": 2, "modes": 4, "link_type": 5, "name": 6, "speed_ab": -1}
     nodes_fields = {"node_id": 0, "is_centroid": 1}
 
     proj_folder = join(folder_path, "project")
@@ -118,6 +185,9 @@ def test_procedure(ae, folder_path):
 
     project_links = project.network.links.data
     assert project_links.shape[0] == 5
+    assert sorted(project_links["link_id"].tolist()) == [1, 2, 3, 4, 5]
+    assert "fifth link" in project_links["name"].tolist()
+    assert project_links["speed_ab"].isna().all()
 
     project_nodes = project.network.nodes.data
     assert project_nodes.shape[0] == 4
@@ -129,3 +199,27 @@ def test_procedure(ae, folder_path):
     modes = project.network.modes
     for mode in ["a", "r", "x"]:
         assert mode in modes.all_modes().keys()
+
+
+def test_procedure_without_link_id(ae, folder_path):
+    load_test_layer(folder_path, "node")
+    load_test_layer(folder_path, "link")
+
+    nodes = QgsProject.instance().mapLayersByName("node")[0]
+    links = QgsProject.instance().mapLayersByName("link")[0]
+
+    links_fields = {"link_id": -1, "direction": 2, "modes": 4, "link_type": 5}
+    nodes_fields = {"node_id": 0, "is_centroid": 1}
+
+    proj_folder = join(folder_path, "project")
+    parent = CreatesTranspoNetDialog(ae)
+    dialog = CreatesTranspoNetProcedure(parent, proj_folder, nodes, nodes_fields, links, links_fields)
+
+    dialog.doWork()
+
+    project = Project()
+    project.open(proj_folder)
+
+    project_links = project.network.links.data
+    assert project_links.shape[0] == 5
+    assert sorted(project_links["link_id"].tolist()) == [1, 2, 3, 4, 5]


### PR DESCRIPTION
Fix field list on Create project from layers

The tool offered fields it should not and hid one option it should have.

* a_node, b_node and distance can no longer be pre-defined. All three are computed by the database triggers from the link geometry, so any value brought from the layer was silently overwritten. They are also filtered out of the available layer fields, so they cannot be added as extra fields either.
* Only the standard network fields are listed now. The list is no longer padded with the one-way/two-way fields from parameters.yml (name, cycleway*, busway*, lanes_ab/ba, capacity_ab/ba, speed_ab/ba). Any other field is up to the user to bring from the layer being imported.
* link_id can be initialized. Its Initialize? box is the only enabled one, and when checked the links are numbered sequentially instead of read from the layer.

Dropping a_node/b_node from the INSERT altogether does not work: the links table has CHECK(TYPEOF(a_node) == "integer") and the trigger that resolves them runs after insert, so a NULL fails the check before it is ever overwritten. They are now seeded with 0, the same way Links.new() does it internally.

Also fixes the nodes branch mutating aequilibrae"s module-level req_node_flds list in place, and replaces the setChecked toggle trick that built the source comboboxes by relying on the row lookup falling through to a None parent.


@