### PR TITLE
Fix Windows plugin load failing before the dependency install

### DIFF
--- a/.github/workflows/WindowsRelease.yml
+++ b/.github/workflows/WindowsRelease.yml
@@ -40,7 +40,7 @@ jobs:
           Start-Process -FilePath "$qgisExec" -ArgumentList "-m pip install -r $pluginPath\test\requirements_test.txt" -NoNewWindow -Wait
           Set-Location "$aeqPath"
           Start-Process -FilePath "$qgisExec" -ArgumentList "download_extra_packages_class.py" -NoNewWindow -Wait
-          $env:PYTHONPATH = "$env:PYTHONPATH;APPDATA\QGIS\QGIS3\profiles\default\python\plugins"
+          $env:PYTHONPATH = "$env:PYTHONPATH;$pluginPath;$aeqPath\packages"
           Set-Location "$pluginPath"
           Start-Process -FilePath "$qgisExec" -ArgumentList "-m pytest test --report-log=.\log.jsonl" -NoNewWindow -Wait
 
@@ -59,7 +59,7 @@ jobs:
           Start-Process -FilePath "$qgisExec" -ArgumentList "-m pip install -r $pluginPath\test\requirements_test.txt" -NoNewWindow -Wait
           Set-Location "$aeqPath"
           Start-Process -FilePath "$qgisExec" -ArgumentList "download_extra_packages_class.py" -NoNewWindow -Wait
-          $env:PYTHONPATH = "$env:PYTHONPATH;APPDATA\QGIS\QGIS3\profiles\default\python\plugins"
+          $env:PYTHONPATH = "$env:PYTHONPATH;$pluginPath;$aeqPath\packages"
           Set-Location "$pluginPath"
           Start-Process -FilePath "$qgisExec" -ArgumentList "-m pytest test --report-log=$pluginPath\log.jsonl" -NoNewWindow -Wait
 
@@ -72,7 +72,13 @@ jobs:
         shell: pwsh
         run: |
           $pluginPath = "$env:APPDATA\QGIS\QGIS3\profiles\default\python\plugins"
-          $fails = Select-String -Path .\*.jsonl -Pattern 'failed'
+          $log = "$pluginPath\log.jsonl"
+          # No report at all means pytest died before running anything, which used to pass unnoticed
+          if (-not (Test-Path $log)) {
+              Write-Error "No test report at $log - the test run did not complete"
+              exit 1
+          }
+          $fails = Select-String -Path $log -Pattern 'failed'
           if ($fails.Matches.Length -gt 0) {
               Write-Error "Check for errors in the tests run"
               exit 1

--- a/qaequilibrae/qaequilibrae.py
+++ b/qaequilibrae/qaequilibrae.py
@@ -19,13 +19,6 @@ from qgis.core import QgsProject, QgsExpressionContextUtils, QgsApplication, Qgs
 from qaequilibrae import set_aequilibrae_menu_instance
 from qaequilibrae.message import messages
 from qaequilibrae.pandas_compat import ensure_regex_capable_strings
-from qaequilibrae.modules.common_tools import EditSnapping
-from qaequilibrae.modules.menu_actions import run_load_project, run_module, run_show_project_data
-from qaequilibrae.modules.menu_actions import run_desire_lines, run_scenario_comparison, run_import_gtfs
-from qaequilibrae.modules.menu_actions import run_distribution_models, run_stacked_bandwidths, run_pt_explore
-from qaequilibrae.modules.menu_actions import run_shortest_path, run_dist_matrix, run_traffic_assig, create_scenarios
-from qaequilibrae.modules.menu_actions import run_route_choice, run_pt_skim, last_folder, load_skim_viewer
-from qaequilibrae.modules.processing_provider.provider import Provider
 
 sys.path.insert(0, join(dirname(__file__), "packages"))
 
@@ -61,6 +54,19 @@ else:
                 QMessageBox.information(None, "Information", msg.third_message)
         else:
             QMessageBox.information(None, "Information", msg.fourth_message)
+
+# Everything under qaequilibrae.modules reaches AequilibraE at import time, so these imports can only
+# happen after "packages" is on sys.path and populated. Moving any of them above the block above
+# turns a first run without the dependencies into a ModuleNotFoundError while QGIS is still loading
+# the plugin, which is exactly when the user should be getting offered the installation instead.
+from qaequilibrae.modules.common_tools import EditSnapping  # noqa: E402
+from qaequilibrae.modules.menu_actions import run_load_project, run_module, run_show_project_data  # noqa: E402
+from qaequilibrae.modules.menu_actions import run_desire_lines, run_scenario_comparison, run_import_gtfs  # noqa: E402
+from qaequilibrae.modules.menu_actions import run_distribution_models, run_stacked_bandwidths  # noqa: E402
+from qaequilibrae.modules.menu_actions import run_shortest_path, run_dist_matrix, run_traffic_assig  # noqa: E402
+from qaequilibrae.modules.menu_actions import run_route_choice, run_pt_skim, last_folder, load_skim_viewer  # noqa: E402
+from qaequilibrae.modules.menu_actions import run_pt_explore, create_scenarios  # noqa: E402
+from qaequilibrae.modules.processing_provider.provider import Provider  # noqa: E402
 
 if hasattr(Qt, "AA_EnableHighDpiScaling"):
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
-from os.path import join
+import sys
+from os.path import dirname, join
 from shutil import copytree
 from uuid import uuid4
 
@@ -7,8 +8,14 @@ from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QApplication
 from qgis.core import QgsProject
 
-from qaequilibrae.modules.common_tools import ReportDialog
-from qaequilibrae.qaequilibrae import AequilibraEMenu
+# AequilibraE and the other dependencies are vendored in qaequilibrae/packages, and only qaequilibrae.py
+# puts that folder on sys.path - which these tests never reach, because they import plugin modules
+# directly. Relying on the runner to export PYTHONPATH instead is what left Windows CI unable to import
+# AequilibraE at all. Appended rather than inserted, so an installed AequilibraE still takes precedence.
+sys.path.append(join(dirname(dirname(__file__)), "qaequilibrae", "packages"))
+
+from qaequilibrae.modules.common_tools import ReportDialog  # noqa: E402
+from qaequilibrae.qaequilibrae import AequilibraEMenu  # noqa: E402
 
 
 @pytest.fixture

--- a/test/test_plugin_import_order.py
+++ b/test/test_plugin_import_order.py
@@ -1,0 +1,113 @@
+"""Guards the import order that lets the plugin install its own dependencies.
+
+AequilibraE and the rest of the plugin's dependencies live in ``qaequilibrae/packages``, which only
+goes on ``sys.path`` -- and only gets installed -- part way down ``qaequilibrae.py``. Any module
+imported above that point that reaches AequilibraE turns a first run without the dependencies into a
+``ModuleNotFoundError`` while QGIS is loading the plugin, so the installation is never offered.
+
+Nothing else catches it: CI and every developer machine already have AequilibraE importable, so the
+imports resolve there and the ordering only matters on a fresh install (in practice, Windows).
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+PLUGIN_MODULE = "qaequilibrae.qaequilibrae"
+
+
+def source_of(module: str):
+    """The file backing a dotted module name, and whether it is a package, or None if neither."""
+    path = PLUGIN_ROOT.joinpath(*module.split("."))
+    if (path / "__init__.py").exists():
+        return path / "__init__.py", True
+    if path.with_suffix(".py").exists():
+        return path.with_suffix(".py"), False
+    return None, False
+
+
+def import_time_nodes(tree: ast.AST):
+    """Import statements that run when the module is imported, so everything outside a function."""
+    pending = list(ast.iter_child_nodes(tree))
+    while pending:
+        node = pending.pop()
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue  # deferred until the function is called, which is what the lazy imports do
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            yield node
+        else:
+            pending.extend(ast.iter_child_nodes(node))
+
+
+def imported_names(node, module: str, is_package: bool):
+    """The modules a single import statement can pull in, as dotted names."""
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+
+    if node.level == 0:
+        base = node.module
+    else:
+        package = module if is_package else module.rpartition(".")[0]
+        for _ in range(node.level - 1):
+            package = package.rpartition(".")[0]
+        base = f"{package}.{node.module}" if node.module else package
+
+    # `from x import y` imports x, and y too when y is a submodule rather than an attribute
+    return [base] + [f"{base}.{alias.name}" for alias in node.names]
+
+
+def bootstrap_line(tree: ast.AST) -> int:
+    """The line where qaequilibrae.py puts the vendored `packages` folder on sys.path."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute) or node.attr != "insert":
+            continue
+        target = ast.unparse(node.value)
+        if target in ("sys.path", "path"):
+            return node.lineno
+    return -1
+
+
+def imports_reaching_aequilibrae(module: str, chain: list, seen: set, before_line=None):
+    """Walks import-time imports from *module*, reporting the ones that land on AequilibraE."""
+    if module in seen:
+        return
+    seen.add(module)
+
+    path, is_package = source_of(module)
+    if path is None:  # third party, stdlib, or a name imported from a module rather than a submodule
+        return
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in import_time_nodes(tree):
+        if before_line is not None and node.lineno > before_line:
+            continue
+        for name in imported_names(node, module, is_package):
+            if name == "aequilibrae" or name.startswith("aequilibrae."):
+                yield chain + [f"{module} (line {node.lineno})"], name
+            elif name.startswith("qaequilibrae"):
+                yield from imports_reaching_aequilibrae(name, chain + [module], seen, before_line=None)
+
+
+@pytest.fixture(scope="module")
+def plugin_tree():
+    path, _ = source_of(PLUGIN_MODULE)
+    assert path is not None, f"Cannot find the source of {PLUGIN_MODULE}"
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def test_plugin_puts_its_packages_folder_on_the_path(plugin_tree):
+    assert bootstrap_line(plugin_tree) > 0, f"{PLUGIN_MODULE} no longer adds `packages` to sys.path"
+
+
+def test_nothing_imports_aequilibrae_before_the_packages_bootstrap(plugin_tree):
+    offenders = list(
+        imports_reaching_aequilibrae(PLUGIN_MODULE, chain=[], seen=set(), before_line=bootstrap_line(plugin_tree))
+    )
+
+    described = "\n".join(f"  {name} <- {' <- '.join(reversed(chain))}" for chain, name in offenders)
+    assert not offenders, (
+        "These imports run before `packages` is on sys.path, so the plugin dies with a "
+        f"ModuleNotFoundError instead of offering to install its dependencies:\n{described}"
+    )

--- a/test/test_plugin_import_order.py
+++ b/test/test_plugin_import_order.py
@@ -41,21 +41,33 @@ def import_time_nodes(tree: ast.AST):
             pending.extend(ast.iter_child_nodes(node))
 
 
+def with_parents(name: str):
+    """A dotted name preceded by every package Python runs on the way to it."""
+    parts = name.split(".")
+    return [".".join(parts[: depth + 1]) for depth in range(len(parts))]
+
+
 def imported_names(node, module: str, is_package: bool):
-    """The modules a single import statement can pull in, as dotted names."""
+    """The modules a single import statement can pull in, as dotted names.
+
+    Reaching a submodule executes each package `__init__.py` above it, and several of those
+    re-export dialogs that import AequilibraE, so the parents count as imports of their own.
+    """
     if isinstance(node, ast.Import):
-        return [alias.name for alias in node.names]
-
-    if node.level == 0:
-        base = node.module
+        names = [alias.name for alias in node.names]
     else:
-        package = module if is_package else module.rpartition(".")[0]
-        for _ in range(node.level - 1):
-            package = package.rpartition(".")[0]
-        base = f"{package}.{node.module}" if node.module else package
+        if node.level == 0:
+            base = node.module
+        else:
+            package = module if is_package else module.rpartition(".")[0]
+            for _ in range(node.level - 1):
+                package = package.rpartition(".")[0]
+            base = f"{package}.{node.module}" if node.module else package
 
-    # `from x import y` imports x, and y too when y is a submodule rather than an attribute
-    return [base] + [f"{base}.{alias.name}" for alias in node.names]
+        # `from x import y` imports x, and y too when y is a submodule rather than an attribute
+        names = [base] + [f"{base}.{alias.name}" for alias in node.names]
+
+    return list(dict.fromkeys(parent for name in names for parent in with_parents(name)))
 
 
 def bootstrap_line(tree: ast.AST) -> int:


### PR DESCRIPTION
common_tools was imported at the top of qaequilibrae.py, and its __init__ pulls in auxiliary_functions, which imports aequilibrae at module level. That ran 8 lines above the sys.path.insert for the vendored packages folder and 18 above the install prompt, so on Windows the plugin died with ModuleNotFoundError on every launch, installed or not, and never offered to install anything.

Moved the qaequilibrae.modules imports below the bootstrap, and added a test that walks import-time imports and fails if any of them reaches aequilibrae before the packages folder is on sys.path. CI never caught this because it exports PYTHONPATH to the packages folder before importing.