### PR TITLE
Minor corrections

### DIFF
--- a/docs/source/menus_in_detail/project.rst
+++ b/docs/source/menus_in_detail/project.rst
@@ -26,7 +26,11 @@ a project, and **Project > Close project** to close it.
 
 Keep in mind that to open another project or to create a new one, you **must**
 close the currently open project, otherwise AequilibraE is going to return an
-error.
+error. That applies to the tools that build a model as well
+(:ref:`from OSM <create_project_from_osm>`,
+:ref:`from layers <project_from_layers>` or
+:ref:`from an example <create_example>`), since each of them leaves the model it
+created open, with its layers listed in the Project tab.
 
 .. _run_procedures:
 

--- a/docs/source/processing_provider.rst
+++ b/docs/source/processing_provider.rst
@@ -294,6 +294,9 @@ defined as the current map canvas on QGIS...
     :align: center
     :alt: Download OSM networks for named place
 
+Once the import is over, the new model is opened and its layers are listed in the
+Project tab, ready to be added to the map.
+
 .. _project_from_layers:
 
 Project from layers
@@ -352,7 +355,8 @@ In the case of the nodes layer, both fields are mandatory.
     :align: center
     :alt: project_from_layers_nodes
 
-After filling all fields, it is just a matter of saving it!
+After filling all fields, it is just a matter of saving it! The model is opened as soon
+as it is built, and its layers are listed in the Project tab.
 
 After running this tool a sqlite file (spatialite enabled) will be created and
 you can edit the network (create, move or delete links and nodes) and both
@@ -430,8 +434,8 @@ AequilibraE has three different example sets one can use as learning tool, and t
 made available within the QGIS ecosystem.
 
 Within **Project > Create example**, select one of the available models, the desired
-location of the output folder, and just press *Create*. The window will close automatically
-and you can open the project folder in the Project tab.
+location of the output folder, and just press *Create*. The window closes automatically
+and the new model is opened, with its layers listed in the Project tab.
 
 .. image:: images/processing_provider/project_create_example.png
     :align: center

--- a/qaequilibrae/modules/menu_actions/load_project_action.py
+++ b/qaequilibrae/modules/menu_actions/load_project_action.py
@@ -26,28 +26,38 @@ def _project_root(proj_path):
 
 def _run_load_project_from_path(qgis_project, proj_path):
     from aequilibrae.project import Project
-    from aequilibrae.project.tools import MigrationManager
-    from aequilibrae.utils.spatialite_utils import connect_spatialite
 
     if proj_path is None or proj_path == "":
         return
 
     proj_path = _project_root(proj_path)
 
-    if proj_path is not None and len(proj_path) > 0:
-        qgis_project.contents = []
-        qgis_project.project = Project()
+    qgis_project.contents = []
+    qgis_project.project = Project()
 
-        try:
-            qgis_project.project.open(proj_path)
-        except FileNotFoundError as e:
-            if e.args[0] == "Model does not exist. Check your path and try again":
-                qgis_project.iface_error_message(
-                    "Check your path and try again", "FOLDER DOES NOT CONTAIN AN AEQUILIBRAE MODEL"
-                )
-                return
-            else:
-                raise e
+    try:
+        qgis_project.project.open(proj_path)
+    except FileNotFoundError as e:
+        if e.args[0] == "Model does not exist. Check your path and try again":
+            qgis_project.iface_error_message(
+                "Check your path and try again", "FOLDER DOES NOT CONTAIN AN AEQUILIBRAE MODEL"
+            )
+            return
+        else:
+            raise e
+
+    show_project_in_panel(qgis_project, proj_path)
+
+
+def show_project_in_panel(qgis_project, proj_path):
+    """Fills the panel for a project AequilibraE already has open.
+
+    Every way of getting to an open project - the menu, a QGIS project carrying a model, an
+    import from OSM - has to come through here, or the plugin ends up holding a project whose
+    scenarios and layers the panel knows nothing about.
+    """
+    from aequilibrae.project.tools import MigrationManager
+    from aequilibrae.utils.spatialite_utils import connect_spatialite
 
     pth = join(gettempdir(), "aequilibrae_last_folder.txt")
     with open(pth, "w") as file:

--- a/qaequilibrae/modules/project_procedures/create_examples_dialog.py
+++ b/qaequilibrae/modules/project_procedures/create_examples_dialog.py
@@ -72,5 +72,10 @@ class CreateExampleDialog(QtWidgets.QDialog, FORM_CLASS):
             self.output_path.setText(join(new_name, new_folder))
 
     def run(self):
-        create_example(self.output_path.text(), self.place)
+        # Imported here so project_procedures and menu_actions do not import each other at plugin load
+        from qaequilibrae.modules.menu_actions.load_project_action import show_project_in_panel
+
+        # create_example hands back an open project, which is the one the panel goes on to show
+        self.qgis_project.project = create_example(self.output_path.text(), self.place)
+        show_project_in_panel(self.qgis_project, self.output_path.text())
         self.close()

--- a/qaequilibrae/modules/project_procedures/creates_transponet_dialog.py
+++ b/qaequilibrae/modules/project_procedures/creates_transponet_dialog.py
@@ -337,6 +337,13 @@ class CreatesTranspoNetDialog(QtWidgets.QDialog, FORM_CLASS):
         elif val[0] == "update":
             self.progressbar.setValue(val[1])
         elif val[0] == "finished":
+            # Imported here so project_procedures and menu_actions do not import each other at plugin load
+            from qaequilibrae.modules.menu_actions.load_project_action import show_project_in_panel
+
+            # The project the procedure built is left open, so the panel takes it over from here
+            self.qgis_project.project = self.worker_thread.project
+            show_project_in_panel(self.qgis_project, self.worker_thread.proj_folder)
+
             if self.worker_thread.report:
                 dlg2 = ReportDialog(self.iface, self.worker_thread.report)
                 dlg2.show()

--- a/qaequilibrae/modules/project_procedures/project_from_osm_dialog.py
+++ b/qaequilibrae/modules/project_procedures/project_from_osm_dialog.py
@@ -227,7 +227,14 @@ class ProjectFromOSMDialog(QDialog, FORM_CLASS):
             self.failed_to_import()
             return
 
+        # Imported here because menu_actions reaches back into project_procedures while the
+        # plugin is still building its menus, and importing it at module level closes the circle
+        from qaequilibrae.modules.menu_actions.load_project_action import show_project_in_panel
+
         self.qgis_project.project = self.worker_thread.project
+        # The project the import leaves behind is open, but nothing has told the panel about it,
+        # so without this the model shows as loaded with no scenario and no layer to load
+        show_project_in_panel(self.qgis_project, self.worker_thread.output_path)
         self.leave()
 
     def failed_to_import(self):

--- a/qaequilibrae/modules/project_procedures/project_from_osm_dialog.py
+++ b/qaequilibrae/modules/project_procedures/project_from_osm_dialog.py
@@ -227,8 +227,7 @@ class ProjectFromOSMDialog(QDialog, FORM_CLASS):
             self.failed_to_import()
             return
 
-        # Imported here because menu_actions reaches back into project_procedures while the
-        # plugin is still building its menus, and importing it at module level closes the circle
+        # Imported here so project_procedures and menu_actions do not import each other at plugin load
         from qaequilibrae.modules.menu_actions.load_project_action import show_project_in_panel
 
         self.qgis_project.project = self.worker_thread.project

--- a/qaequilibrae/qaequilibrae.py
+++ b/qaequilibrae/qaequilibrae.py
@@ -17,7 +17,7 @@ from qgis.PyQt.QtWidgets import QComboBox, QLabel, QTableWidgetItem, QTableWidge
 from qgis.core import QgsDataSourceUri, QgsVectorLayer, QgsVectorFileWriter
 from qgis.core import QgsProject, QgsExpressionContextUtils, QgsApplication, QgsMessageLog, Qgis
 
-from qaequilibrae import set_aequilibrae_menu_instance
+from qaequilibrae import get_aequilibrae_menu_instance, set_aequilibrae_menu_instance
 from qaequilibrae.message import messages, FAQ_URL
 from qaequilibrae.missing_dependencies import DisabledSnapping, disabled_action, temporary_folder
 from qaequilibrae.pandas_compat import ensure_regex_capable_strings
@@ -227,10 +227,12 @@ class AequilibraEMenu:
         # ##################        SAVING PROJECT CONFIGS       #####################
         QgsProject.instance().readProject.connect(self.reload_project)
 
+        self.saving_actions = []
         for action in ["mActionSaveProject", "mActionSaveProjectAs"]:
             temp_saving = self.iface.mainWindow().findChild(QAction, action)
             if temp_saving:
                 temp_saving.triggered.connect(self.save_in_project)
+                self.saving_actions.append(temp_saving)
 
     def get_logger(self):
         if DEPENDENCY_ERROR is not None:
@@ -308,8 +310,39 @@ class AequilibraEMenu:
         self.initProcessing()
 
     def unload(self):
+        """Undoes what __init__ put in place, which QGIS asks for when the plugin is disabled,
+        reloaded or uninstalled. Whatever is left behind here outlives the plugin: the panel
+        stays docked to the main window, and QGIS keeps signalling into a menu that is gone.
+        """
         if self.provider in QgsApplication.processingRegistry().providers():
             QgsApplication.processingRegistry().removeProvider(self.provider)
+        self.provider = None
+
+        connections = [
+            (QgsProject.instance().layerRemoved, self.layerRemoved),
+            (QgsProject.instance().readProject, self.reload_project),
+        ]
+        connections += [(saving.triggered, self.save_in_project) for saving in self.saving_actions]
+        for signal, slot in connections:
+            try:
+                signal.disconnect(slot)
+            except (TypeError, RuntimeError):
+                # Nothing left connected, or Qt has already taken the sender down
+                pass
+        self.saving_actions = []
+
+        # The panel is the only way of closing a project, and it is on its way out
+        try:
+            self.run_close_project()
+        except Exception as e:
+            self.message_log(self.tr("Could not close the project while unloading: {}").format(e))
+
+        self.iface.removeDockWidget(self.dock)
+        self.dock.setParent(None)
+        self.dock.deleteLater()
+
+        if get_aequilibrae_menu_instance() is self:
+            set_aequilibrae_menu_instance(None)
 
     def removes_temporary_files(self):
         # Removes all the temporary files from previous uses

--- a/test/test_create_examples.py
+++ b/test/test_create_examples.py
@@ -17,3 +17,24 @@ def test_create_example(ae, place_name, folder_path):
 
     folder = Path(f"{folder_path}/example_{place_name}")
     assert isdir(folder)
+
+    ae.run_close_project()
+
+
+def test_created_example_is_opened_in_the_panel(ae, folder_path):
+    """create_example hands back an open project, so the panel shows it instead of the user
+    having to go back through Open project for the model they were just given
+    """
+    dialog = CreateExampleDialog(ae)
+
+    dialog.place = "sioux_falls"
+    dialog.output_path.setText(f"{folder_path}/example_sioux_falls")
+
+    dialog.run()
+
+    assert ae.project is not None
+    assert ae.available_scenarios == ["root"]
+    assert {"links", "nodes"} <= set(ae.layers)
+    assert ae.projectManager.count() == 1
+
+    ae.run_close_project()

--- a/test/test_create_transponet.py
+++ b/test/test_create_transponet.py
@@ -116,6 +116,26 @@ def test_dialog(ae, folder_path):
         assert mode in modes.all_modes().keys()
 
 
+def test_dialog_opens_the_model_it_creates(ae, folder_path):
+    """The procedure leaves the new project open, so the panel takes it over from there"""
+    load_test_layer(folder_path, "node")
+    load_test_layer(folder_path, "link")
+
+    dialog = CreatesTranspoNetDialog(ae)
+    dialog.project_destination.setText(folder_path)
+
+    map_standard_fields(dialog)
+
+    dialog.create_net()
+
+    assert ae.project is dialog.worker_thread.project
+    assert ae.available_scenarios == ["root"]
+    assert {"links", "nodes"} <= set(ae.layers)
+    assert ae.projectManager.count() == 1
+
+    ae.run_close_project()
+
+
 def test_dialog_bringing_extra_field_from_layer(ae, folder_path):
     load_test_layer(folder_path, "node")
     load_test_layer(folder_path, "link")

--- a/test/test_plugin_unload.py
+++ b/test/test_plugin_unload.py
@@ -1,0 +1,45 @@
+"""QGIS calls unload() when the plugin is disabled, reloaded or uninstalled."""
+
+
+def test_unload_takes_the_panel_down(ae, qgis_iface, monkeypatch):
+    """The panel is docked to the QGIS window, so it outlives the plugin unless it is removed"""
+    removed = []
+    monkeypatch.setattr(qgis_iface, "removeDockWidget", removed.append)
+    dock = ae.dock
+
+    ae.unload()
+
+    assert removed == [dock], "the panel was left docked to the QGIS window"
+    assert dock.parent() is None
+
+
+def test_unload_closes_an_open_project(ae_with_project, qgis_iface, monkeypatch):
+    """The panel is the only way of closing a project, so an open one has to go with it"""
+    monkeypatch.setattr(qgis_iface, "removeDockWidget", lambda dock: None)
+    assert ae_with_project.project is not None
+
+    ae_with_project.unload()
+
+    assert ae_with_project.project is None
+    assert ae_with_project.available_scenarios == []
+    assert not ae_with_project.layers
+
+
+def test_unload_stops_qgis_from_signalling_into_the_plugin(ae, qgis_iface, monkeypatch):
+    """A connected signal keeps the menu alive and calls into it long after it was unloaded"""
+    from qgis.core import QgsProject
+
+    monkeypatch.setattr(qgis_iface, "removeDockWidget", lambda dock: None)
+
+    ae.unload()
+
+    # Nothing left to disconnect is precisely what unload has to leave behind
+    for signal, slot in [
+        (QgsProject.instance().layerRemoved, ae.layerRemoved),
+        (QgsProject.instance().readProject, ae.reload_project),
+    ]:
+        try:
+            signal.disconnect(slot)
+            raise AssertionError(f"{slot.__name__} is still connected to QGIS")
+        except TypeError:
+            pass

--- a/test/test_project_from_osm.py
+++ b/test/test_project_from_osm.py
@@ -1,5 +1,6 @@
 from os import listdir, environ, makedirs
 from os.path import join
+from types import SimpleNamespace
 
 import pytest
 from aequilibrae.project import Project
@@ -130,6 +131,30 @@ def test_shows_the_logfile_as_it_is_written(dialog, folder_path):
     shown = dialog.log_view.toPlainText()
     assert shown.count("Downloading data") == 1
     assert "Building Network" in shown
+
+
+def test_panel_shows_the_imported_model(dialog, folder_path, patch_report_dialog):
+    """The import leaves a project open, and the panel is only aware of it if it is told
+
+    Without this the plugin reports a model as open while the panel holds no scenario and no
+    layer to load, so there is no way of getting the network on the screen.
+    """
+    project = Project()
+    project.new(folder_path)
+
+    # Standing in for an import that has just succeeded, so the test does not hit the network
+    dialog.output_path.setText(folder_path)
+    dialog.worker_thread = SimpleNamespace(project=project, output_path=folder_path, report=[], error=None)
+
+    dialog.job_finished()
+
+    ae = dialog.qgis_project
+    assert ae.project is project
+    assert ae.available_scenarios == ["root"]
+    assert {"links", "nodes"} <= set(ae.layers)
+    assert ae.projectManager.count() == 1
+
+    ae.run_close_project()
 
 
 @pytest.mark.skipif(not bool(environ.get("CI")), reason="Runs only in GitHub Action")


### PR DESCRIPTION
* Closes the panel when the plugin is unloaded
* When creating a model from OSM, layers are added to the panel
* When creating a model from scratch (empty model), the model stays open, and layers are loaded
