### PR TITLE
Minor bugs

### DIFF
--- a/qaequilibrae/modules/common_tools/live_log.py
+++ b/qaequilibrae/modules/common_tools/live_log.py
@@ -62,7 +62,11 @@ class LiveLogWidget(QWidget):
             return
         self.text.appendPlainText(msg)
         if self.auto_scroll.isChecked():
-            self.text.ensureCursorVisible()
+            # Drive the scrollbar rather than the cursor. appendPlainText leaves the
+            # text cursor where it was -- usually the very start -- so asking to make
+            # the cursor visible scrolls back to the top instead of following the tail.
+            scrollbar = self.text.verticalScrollBar()
+            scrollbar.setValue(scrollbar.maximum())
 
     def connect_bridge(self, bridge):
         bridge.log_line.connect(self.append)

--- a/qaequilibrae/modules/common_tools/live_log.py
+++ b/qaequilibrae/modules/common_tools/live_log.py
@@ -62,8 +62,7 @@ class LiveLogWidget(QWidget):
             return
         self.text.appendPlainText(msg)
         if self.auto_scroll.isChecked():
-            # Drive the scrollbar rather than the cursor. appendPlainText leaves the
-            # text cursor where it was -- usually the very start -- so asking to make
+            # appendPlainText leaves the text cursor where it was so asking to make
             # the cursor visible scrolls back to the top instead of following the tail.
             scrollbar = self.text.verticalScrollBar()
             scrollbar.setValue(scrollbar.maximum())

--- a/qaequilibrae/modules/common_tools/table_field_lister.py
+++ b/qaequilibrae/modules/common_tools/table_field_lister.py
@@ -2,10 +2,9 @@ from sqlite3 import Connection
 
 
 def find_table_fields(conn: Connection, table_name: str):
-    """Returns the lower-cased column names of *table_name*.
+    """Returns the column names of *table_name*, spelled as the table spells them.
 
     Uses the table-valued form of the pragma so the table name travels as a bound parameter
-    rather than being interpolated into the statement.
-    """
+    rather than being interpolated into the statement."""
     structure = conn.execute("SELECT name FROM pragma_table_info(?);", [table_name]).fetchall()
-    return [x[0].lower() for x in structure]
+    return [x[0] for x in structure]

--- a/qaequilibrae/modules/common_tools/table_field_lister.py
+++ b/qaequilibrae/modules/common_tools/table_field_lister.py
@@ -2,7 +2,7 @@ from sqlite3 import Connection
 
 
 def find_table_fields(conn: Connection, table_name: str):
-    """Returns the column names of *table_name*, spelled as the table spells them.
+    """Returns the column names of *table_name*.
 
     Uses the table-valued form of the pragma so the table name travels as a bound parameter
     rather than being interpolated into the statement."""

--- a/qaequilibrae/modules/gis/compare_scenarios_dialog.py
+++ b/qaequilibrae/modules/gis/compare_scenarios_dialog.py
@@ -15,6 +15,26 @@ sys.modules["qgsfieldcombobox"] = qgis.gui
 sys.modules["qgsmaplayercombobox"] = qgis.gui
 
 
+def directional_field_pairs(fields):
+    """The fields that come as an AB/BA pair, each as a label to show and the two column names.
+
+    The pairing is case-insensitive because a result table mixes cases: AequilibraE capitalises
+    the fields it computes itself (`Preload_AB`, `VOC_AB`), while the flow columns carry the case
+    of the traffic class they belong to. The names handed back are the ones the table actually
+    uses - the label is only ever shown, never used to read a column back, which is what used to
+    leave every capitalised field pointing at a column that was not there.
+    """
+    by_lower = {f.lower(): f for f in fields}
+    pairs = []
+    # Matched on the suffix rather than anywhere in the name, so that a class called "cab" is
+    # not paired with itself through the "ab" in the middle of it
+    for lower, name in by_lower.items():
+        counterpart = by_lower.get(f"{lower[:-2]}ba") if lower.endswith("ab") else None
+        if counterpart is not None:
+            pairs.append((f"{name[:-2]}*", (name, counterpart)))
+    return pairs
+
+
 class CompareScenariosDialog(BaseDialog):
     def __init__(self, qgis_project):
         super().__init__(ui_file=join(dirname(__file__), "forms/ui_compare_scenarios.ui"), qgis_project=qgis_project)
@@ -110,8 +130,8 @@ class CompareScenariosDialog(BaseDialog):
             lst = find_table_fields(conn, cob_results.currentText())
         if self.__init_scenario != cob_scenario.currentText():
             self.qgis_project.project.use_scenario(self.__init_scenario)
-        flds = [x.replace("ab", "*") for x in lst if "ab" in x and x.replace("ab", "ba") in lst]
-        cob_fields.addItems(flds)
+        for label, pair in directional_field_pairs(lst):
+            cob_fields.addItem(label, pair)
 
     def execute_comparison(self):
         if not self.check_inputs():
@@ -139,16 +159,16 @@ class CompareScenariosDialog(BaseDialog):
 
         # Create the bandwidths for the common flow, if requested
         if self.radio_compo.isChecked():
-            exp = QgsExpression(
+            max_value = self.band_max_value(
                 f"""max(maximum(coalesce("{ab_base}",0)),
                         maximum(coalesce("{ab_alt}",0)),
                         maximum(coalesce("{ba_base}",0)),
                         maximum(coalesce("{ba_alt}",0))) """
             )
-            context = self.link_layer.createExpressionContext()
-            max_value = exp.evaluate(context).real
+            if max_value is None:
+                return
 
-            QgsExpressionContextUtils.setProjectVariable(QgsProject.instance(), "aeq_band_max_value", float(max_value))
+            QgsExpressionContextUtils.setProjectVariable(QgsProject.instance(), "aeq_band_max_value", max_value)
             max_value = "@aeq_band_max_value"
 
             # We create the styles for AB and BA directions and add to the fields
@@ -164,15 +184,15 @@ class CompareScenariosDialog(BaseDialog):
 
         # If we want a plot of the differences only
         if self.radio_diff.isChecked():
-            exp = QgsExpression(
+            max_value = self.band_max_value(
                 f"""max(maximum(abs(coalesce("{ab_base}",0)-coalesce("{ab_alt}",0))),
                         maximum(abs(coalesce("{ba_base}",0)-coalesce("{ba_alt}",0)))) """
             )
-            context = self.link_layer.createExpressionContext()
-            max_value = exp.evaluate(context).real
+            if max_value is None:
+                return
             ab_offset = ba_offset = "0"
 
-            QgsExpressionContextUtils.setProjectVariable(QgsProject.instance(), "aeq_band_max_value", float(max_value))
+            QgsExpressionContextUtils.setProjectVariable(QgsProject.instance(), "aeq_band_max_value", max_value)
             max_value = "@aeq_band_max_value"
 
         # We now create the positive and negative bandwidths for each side of the link
@@ -195,6 +215,29 @@ class CompareScenariosDialog(BaseDialog):
         self.link_layer.renderer().symbol().deleteSymbolLayer(0)
         self.link_layer.triggerRepaint()
         self.exit_procedure()
+
+    def band_max_value(self, expression: str):
+        """The value the bandwidths get scaled against, or None if the expression got nowhere.
+
+        `QgsExpression.evaluate` answers NULL for everything it could not work out - a field the
+        layer does not carry, a layer with no features - and the caller cannot tell that from a
+        legitimate zero, so it has to be checked rather than read straight through.
+        """
+        exp = QgsExpression(expression)
+        value = exp.evaluate(self.link_layer.createExpressionContext())
+        if value is not None:
+            return float(value)
+
+        reason = exp.evalErrorString() or exp.parserErrorString() or self.tr("no value came back")
+        self.qgis_project.iface_error_message(
+            self.tr("Could not measure the fields being compared: {}").format(reason),
+            self.tr("Scenario comparison"),
+        )
+        # Both are the band sizes as text by now, and a second run reads them as numbers again
+        self.sizevaluechange()
+        self.spacevaluechange()
+        self.but_run.setEnabled(True)
+        return None
 
     def check_inputs(self):
         for combo in [
@@ -226,8 +269,9 @@ class CompareScenariosDialog(BaseDialog):
         v2 = self.cob_alt_scenario.currentText()
         v3 = self.cob_base_result.currentText()
         v4 = self.cob_alternative_result.currentText()
-        v5 = self.cob_base_data.currentText()
-        v6 = self.cob_alternative_data.currentText()
+        # The columns as the result tables spell them, rather than as the combos show them
+        base_fields = list(self.cob_base_data.currentData())
+        alter_fields = list(self.cob_alternative_data.currentData())
 
         # Load base scenario data
         if v1 != self.__init_scenario:
@@ -235,8 +279,7 @@ class CompareScenariosDialog(BaseDialog):
         base_links = self.qgis_project.project.network.links.data
         base_links = base_links[columns]
         base_lyr_result = load_result_table(self.qgis_project.project, v3)
-        base_cols = ["link_id"]
-        base_cols.extend([x for x in base_lyr_result.columns if v5[:-1] in x and "_tot" not in x])
+        base_cols = ["link_id"] + base_fields
 
         # Load alternative scenario data
         if v1 != v2:
@@ -244,8 +287,7 @@ class CompareScenariosDialog(BaseDialog):
         alter_links = self.qgis_project.project.network.links.data
         alter_links = alter_links[columns]
         alter_lyr_result = load_result_table(self.qgis_project.project, v4)
-        alter_cols = ["link_id"]
-        alter_cols.extend([x for x in alter_lyr_result.columns if v6[:-1] in x and "_tot" not in x])
+        alter_cols = ["link_id"] + alter_fields
 
         # Go back to the currently selected scenario
         self.qgis_project.project.use_scenario(self.__init_scenario)
@@ -258,13 +300,8 @@ class CompareScenariosDialog(BaseDialog):
         alter_links = alter_links.merge(alter_lyr_result[alter_cols], on="link_id")
         alter_links.columns = [f"alternative_{x}" if "geometry" not in x else "geometry" for x in alter_links.columns]
 
-        txt = f"base_{v5}"
-        data_fields = [[txt.replace("*", "ab"), txt.replace("*", "ba")]]
-        values = {txt.replace("*", "ab"): 0, txt.replace("*", "ba"): 0}
-        txt = f"alternative_{v6}"
-        data_fields.append([txt.replace("*", "ab"), txt.replace("*", "ba")])
-        values[txt.replace("*", "ab")] = 0
-        values[txt.replace("*", "ba")] = 0
+        data_fields = [[f"base_{f}" for f in base_fields], [f"alternative_{f}" for f in alter_fields]]
+        values = {field: 0 for pair in data_fields for field in pair}
 
         base_cols = ["base_link_id", "base_a_node", "base_b_node", "geometry"]
         alter_cols = ["alternative_link_id", "alternative_a_node", "alternative_b_node", "geometry"]

--- a/qaequilibrae/modules/gis/compare_scenarios_dialog.py
+++ b/qaequilibrae/modules/gis/compare_scenarios_dialog.py
@@ -16,18 +16,10 @@ sys.modules["qgsmaplayercombobox"] = qgis.gui
 
 
 def directional_field_pairs(fields):
-    """The fields that come as an AB/BA pair, each as a label to show and the two column names.
-
-    The pairing is case-insensitive because a result table mixes cases: AequilibraE capitalises
-    the fields it computes itself (`Preload_AB`, `VOC_AB`), while the flow columns carry the case
-    of the traffic class they belong to. The names handed back are the ones the table actually
-    uses - the label is only ever shown, never used to read a column back, which is what used to
-    leave every capitalised field pointing at a column that was not there.
-    """
+    """AB/BA pairs as (label, (ab, ba)), matched case-insensitively and named as the table names them."""
     by_lower = {f.lower(): f for f in fields}
     pairs = []
-    # Matched on the suffix rather than anywhere in the name, so that a class called "cab" is
-    # not paired with itself through the "ab" in the middle of it
+    # Suffix rather than substring, so a class called "cab" is not paired with itself
     for lower, name in by_lower.items():
         counterpart = by_lower.get(f"{lower[:-2]}ba") if lower.endswith("ab") else None
         if counterpart is not None:
@@ -217,12 +209,7 @@ class CompareScenariosDialog(BaseDialog):
         self.exit_procedure()
 
     def band_max_value(self, expression: str):
-        """The value the bandwidths get scaled against, or None if the expression got nowhere.
-
-        `QgsExpression.evaluate` answers NULL for everything it could not work out - a field the
-        layer does not carry, a layer with no features - and the caller cannot tell that from a
-        legitimate zero, so it has to be checked rather than read straight through.
-        """
+        """Value the bandwidths scale against, or None if the expression could not be evaluated."""
         exp = QgsExpression(expression)
         value = exp.evaluate(self.link_layer.createExpressionContext())
         if value is not None:
@@ -233,7 +220,7 @@ class CompareScenariosDialog(BaseDialog):
             self.tr("Could not measure the fields being compared: {}").format(reason),
             self.tr("Scenario comparison"),
         )
-        # Both are the band sizes as text by now, and a second run reads them as numbers again
+        # Both are expression text by now, and a second run reads them as numbers again
         self.sizevaluechange()
         self.spacevaluechange()
         self.but_run.setEnabled(True)
@@ -269,7 +256,7 @@ class CompareScenariosDialog(BaseDialog):
         v2 = self.cob_alt_scenario.currentText()
         v3 = self.cob_base_result.currentText()
         v4 = self.cob_alternative_result.currentText()
-        # The columns as the result tables spell them, rather than as the combos show them
+        # The real column names, not the starred labels
         base_fields = list(self.cob_base_data.currentData())
         alter_fields = list(self.cob_alternative_data.currentData())
 

--- a/qaequilibrae/modules/gis/compare_scenarios_dialog.py
+++ b/qaequilibrae/modules/gis/compare_scenarios_dialog.py
@@ -22,7 +22,7 @@ def directional_field_pairs(fields):
     # Suffix rather than substring, so a class called "cab" is not paired with itself
     for lower, name in by_lower.items():
         counterpart = by_lower.get(f"{lower[:-2]}ba") if lower.endswith("ab") else None
-        if counterpart is not None:
+        if counterpart:
             pairs.append((f"{name[:-2]}*", (name, counterpart)))
     return pairs
 
@@ -220,7 +220,7 @@ class CompareScenariosDialog(BaseDialog):
             self.tr("Could not measure the fields being compared: {}").format(reason),
             self.tr("Scenario comparison"),
         )
-        # Both are expression text by now, and a second run reads them as numbers again
+        # Reset `band_size` and `space_size` after replacing them with expressions.
         self.sizevaluechange()
         self.spacevaluechange()
         self.but_run.setEnabled(True)
@@ -256,7 +256,6 @@ class CompareScenariosDialog(BaseDialog):
         v2 = self.cob_alt_scenario.currentText()
         v3 = self.cob_base_result.currentText()
         v4 = self.cob_alternative_result.currentText()
-        # The real column names, not the starred labels
         base_fields = list(self.cob_base_data.currentData())
         alter_fields = list(self.cob_alternative_data.currentData())
 

--- a/qaequilibrae/modules/menu_actions/load_project_action.py
+++ b/qaequilibrae/modules/menu_actions/load_project_action.py
@@ -31,10 +31,10 @@ def _run_load_project_from_path(qgis_project, proj_path):
     proj_path = _project_root(proj_path)
 
     qgis_project.contents = []
-    qgis_project.project = Project()
+    project = Project()
 
     try:
-        qgis_project.project.open(proj_path)
+        project.open(proj_path)
     except FileNotFoundError as e:
         if e.args[0] == "Model does not exist. Check your path and try again":
             qgis_project.iface_error_message(
@@ -44,6 +44,7 @@ def _run_load_project_from_path(qgis_project, proj_path):
         else:
             raise e
 
+    qgis_project.project = project
     show_project_in_panel(qgis_project, proj_path)
 
 

--- a/qaequilibrae/modules/menu_actions/load_project_action.py
+++ b/qaequilibrae/modules/menu_actions/load_project_action.py
@@ -44,8 +44,23 @@ def _run_load_project_from_path(qgis_project, proj_path):
         else:
             raise e
 
-    qgis_project.project = project
-    show_project_in_panel(qgis_project, proj_path)
+    try:
+        qgis_project.project = project
+        show_project_in_panel(qgis_project, proj_path)
+    except Exception:
+        try:
+            qgis_project.remove_aequilibrae_layers()
+        except Exception:
+            pass
+        qgis_project.cob_scenarios.clear()
+        qgis_project.projectManager.clear()
+        qgis_project.available_scenarios.clear()
+        qgis_project.matrices.clear()
+        qgis_project.layers.clear()
+        if qgis_project.project is project:
+            qgis_project.project = None
+        project.close()
+        raise
 
 
 def show_project_in_panel(qgis_project, proj_path):

--- a/qaequilibrae/modules/paths_procedures/create_py_strings.py
+++ b/qaequilibrae/modules/paths_procedures/create_py_strings.py
@@ -18,7 +18,7 @@ def create_strings(dct: dict):
 \tgraph.set_skimming({})
 \tgraph.set_blocked_centroid_flows({})
 \n\tdemand = matrices.get_matrix('{}')
-\tdemand.computational_view(['{}'])
+\tdemand.computational_view({})
 \n\ttraffic_classes.extend([TrafficClass(name='{}', graph=graph, matrix=demand)])
 """
     for params in dct["classes"]:

--- a/qaequilibrae/modules/paths_procedures/traffic_assignment_dialog.py
+++ b/qaequilibrae/modules/paths_procedures/traffic_assignment_dialog.py
@@ -1,4 +1,4 @@
-from collections import Counter
+from collections import defaultdict
 from tempfile import gettempdir
 from os.path import dirname, join
 from pathlib import Path
@@ -527,11 +527,13 @@ class TrafficAssignmentDialog(BaseDialog):
         if not mat_name:
             raise AttributeError("Matrix not set")
 
-        class_name = self.ln_class_name.text()
+        # Stripped, since the name goes on to name the result columns
+        class_name = self.ln_class_name.text().strip()
         if not class_name:
             self.qgis_project.iface_error_message(self.tr("Class name cannot be empty"))
             return
-        if class_name in self.traffic_classes:
+        # Folded, because SQLite refuses two columns that differ only by case
+        if class_name.lower() in {name.lower() for name in self.traffic_classes}:
             self.qgis_project.iface_error_message(self.tr("Class name already used"))
             return
 
@@ -544,13 +546,7 @@ class TrafficAssignmentDialog(BaseDialog):
         user_classes = [matrix.names[i] for i in rows]
         matrix.computational_view(user_classes)
 
-        # AequilibraE names the result columns after the matrix cores, so two classes reading
-        # cores of the same name write the same column twice - and that only fails once the
-        # results are saved, with the whole assignment already run. Class names are unique, so
-        # they are what tells the columns apart: a class reading a single core lends it its own
-        # name, and one reading several prefixes each of them. Only the labels change - the
-        # numbers are already in `matrix_view`, and the cores in the file keep their own names,
-        # which is why `class_cores` has to hold on to them for the YAML config.
+        # Columns are named after the cores: relabel with the class name, keep the real ones for the YAML
         self.class_cores[class_name] = user_classes
         if len(user_classes) == 1:
             matrix.view_names = [class_name]
@@ -879,14 +875,12 @@ class TrafficAssignmentDialog(BaseDialog):
         return tries_setup
 
     def __repeated_result_fields(self):
-        """The names the result columns are built from, for any that more than one class claims.
-
-        Prefixing the cores with the class name in `_create_traffic_class` is what normally keeps
-        these apart, and unique class names make that enough - but nothing stops two prefixed
-        names from meeting in the middle, and finding out at save time costs a whole assignment.
-        """
-        claimed = Counter(name for cls in self.traffic_classes.values() for name in cls.matrix.view_names)
-        return sorted(name for name, times in claimed.items() if times > 1)
+        """Result field names claimed by more than one class, folded as SQLite folds column names."""
+        claimed = defaultdict(list)
+        for cls in self.traffic_classes.values():
+            for name in cls.matrix.view_names:
+                claimed[name.lower()].append(name)
+        return sorted({name for claims in claimed.values() if len(claims) > 1 for name in claims})
 
     def signal_handler(self, val):
         if val[0] == "start":

--- a/qaequilibrae/modules/paths_procedures/traffic_assignment_dialog.py
+++ b/qaequilibrae/modules/paths_procedures/traffic_assignment_dialog.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from tempfile import gettempdir
 from os.path import dirname, join
 from pathlib import Path
@@ -52,6 +53,7 @@ class TrafficAssignmentDialog(BaseDialog):
         self.current_modes = []
         self.assignment = TrafficAssignment()
         self.traffic_classes = {}
+        self.class_cores = {}
         self.vdf_parameters = {}
         self.matrices = pd.DataFrame([])
         self.skims = {}
@@ -260,7 +262,7 @@ class TrafficAssignmentDialog(BaseDialog):
                 pth = Path(info.matrix.file_path).name
                 df = self.project.matrices.list()
                 dc["matrix_name"] = df.loc[df["file_name"] == pth]["name"].values[0]
-                dc["matrix_core"] = info.matrix.view_names[0]
+                dc["matrix_core"] = self.class_cores[tc][0]
                 dc["network_mode"] = info.mode
                 dc["pce"] = info.pce
                 # Taken from the class rather than from the checkbox, which only reflects the class
@@ -337,7 +339,7 @@ class TrafficAssignmentDialog(BaseDialog):
                             self.skims[tc] if self.skims[tc] else [],
                             info.graph.block_centroid_flows,
                             df.loc[df["file_name"] == pth]["name"].values[0],
-                            info.matrix.view_names[0],
+                            self.class_cores[tc][0],
                             tc,
                         ]
                     ]
@@ -526,8 +528,12 @@ class TrafficAssignmentDialog(BaseDialog):
             raise AttributeError("Matrix not set")
 
         class_name = self.ln_class_name.text()
+        if not class_name:
+            self.qgis_project.iface_error_message(self.tr("Class name cannot be empty"))
+            return
         if class_name in self.traffic_classes:
             self.qgis_project.iface_error_message(self.tr("Class name already used"))
+            return
 
         matrix = self.project.matrices.get_matrix(mat_name)
 
@@ -537,6 +543,19 @@ class TrafficAssignmentDialog(BaseDialog):
         rows = [s.row() for s in sel if s.column() == 0]
         user_classes = [matrix.names[i] for i in rows]
         matrix.computational_view(user_classes)
+
+        # AequilibraE names the result columns after the matrix cores, so two classes reading
+        # cores of the same name write the same column twice - and that only fails once the
+        # results are saved, with the whole assignment already run. Class names are unique, so
+        # they are what tells the columns apart: a class reading a single core lends it its own
+        # name, and one reading several prefixes each of them. Only the labels change - the
+        # numbers are already in `matrix_view`, and the cores in the file keep their own names,
+        # which is why `class_cores` has to hold on to them for the YAML config.
+        self.class_cores[class_name] = user_classes
+        if len(user_classes) == 1:
+            matrix.view_names = [class_name]
+        else:
+            matrix.view_names = [f"{class_name}_{core}" for core in user_classes]
 
         nan_mask = np.isnan(matrix.matrix_view)
         nan_count = np.count_nonzero(nan_mask)
@@ -829,6 +848,11 @@ class TrafficAssignmentDialog(BaseDialog):
             self.error = self.tr("No traffic classes to assign")
             return False
 
+        repeated = self.__repeated_result_fields()
+        if repeated:
+            self.error = self.tr("More than one class writes the result fields: {}").format(", ".join(repeated))
+            return False
+
         self.scenario_name = self.output_scenario_name.text()
         if not self.scenario_name:
             self.error = self.tr("Missing scenario name")
@@ -853,6 +877,16 @@ class TrafficAssignmentDialog(BaseDialog):
         self.temp_path = gettempdir()
         tries_setup = self.set_assignment()
         return tries_setup
+
+    def __repeated_result_fields(self):
+        """The names the result columns are built from, for any that more than one class claims.
+
+        Prefixing the cores with the class name in `_create_traffic_class` is what normally keeps
+        these apart, and unique class names make that enough - but nothing stops two prefixed
+        names from meeting in the middle, and finding out at save time costs a whole assignment.
+        """
+        claimed = Counter(name for cls in self.traffic_classes.values() for name in cls.matrix.view_names)
+        return sorted(name for name, times in claimed.items() if times > 1)
 
     def signal_handler(self, val):
         if val[0] == "start":

--- a/qaequilibrae/modules/paths_procedures/traffic_assignment_dialog.py
+++ b/qaequilibrae/modules/paths_procedures/traffic_assignment_dialog.py
@@ -12,7 +12,7 @@ from aequilibrae.paths.traffic_assignment import TrafficAssignment
 from aequilibrae.paths.traffic_class import TrafficClass
 from aequilibrae.paths.vdf import all_vdf_functions
 from qgis.PyQt import QtWidgets
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import QItemSelectionModel, Qt
 from qgis.PyQt.QtGui import QColor, QPalette
 from qgis.PyQt.QtWidgets import QTableWidgetItem, QLineEdit, QComboBox, QCheckBox, QPushButton, QAbstractItemView
 
@@ -181,7 +181,12 @@ class TrafficAssignmentDialog(BaseDialog):
                     # From the combo rather than from the config, so that the cores listed below
                     # come from the same matrix `_create_traffic_class` is going to pick up
                     names = self.project.matrices.get_matrix(self.cob_matrices.currentText()).names
-                    self.tbl_core_list.selectRow(names.index(value["matrix_core"]))
+                    cores = value.get("matrix_cores", [value["matrix_core"]])
+                    self.tbl_core_list.clearSelection()
+                    selection = self.tbl_core_list.selectionModel()
+                    flags = QItemSelectionModel.SelectionFlag.Select | QItemSelectionModel.SelectionFlag.Rows
+                    for core in cores:
+                        selection.select(selection.model().index(names.index(core), 0), flags)
                     self.ln_class_name.setText(key)
                     self.pce_setter.setValue(value["pce"])
                     self.chb_check_centroids.setChecked(value["blocked_centroid_flows"])
@@ -262,7 +267,10 @@ class TrafficAssignmentDialog(BaseDialog):
                 pth = Path(info.matrix.file_path).name
                 df = self.project.matrices.list()
                 dc["matrix_name"] = df.loc[df["file_name"] == pth]["name"].values[0]
-                dc["matrix_core"] = self.class_cores[tc][0]
+                cores = self.class_cores[tc]
+                dc["matrix_core"] = cores[0]
+                if len(cores) > 1:
+                    dc["matrix_cores"] = cores
                 dc["network_mode"] = info.mode
                 dc["pce"] = info.pce
                 # Taken from the class rather than from the checkbox, which only reflects the class
@@ -339,7 +347,7 @@ class TrafficAssignmentDialog(BaseDialog):
                             self.skims[tc] if self.skims[tc] else [],
                             info.graph.block_centroid_flows,
                             df.loc[df["file_name"] == pth]["name"].values[0],
-                            self.class_cores[tc][0],
+                            self.class_cores[tc],
                             tc,
                         ]
                     ]

--- a/qaequilibrae/modules/processing_provider/model_building/create_empty_project.py
+++ b/qaequilibrae/modules/processing_provider/model_building/create_empty_project.py
@@ -94,8 +94,7 @@ class CreateEmptyProject(QgsProcessingAlgorithm):
         return {"Output": project_folder}
 
     def show_in_panel(self, project, project_folder, feedback):
-        """Hands the new model to the panel, the way every other way of creating one does.
-        """
+        """Hands the new model to the panel, the way every other way of creating one does."""
         from qaequilibrae import get_aequilibrae_menu_instance
         from qaequilibrae.modules.menu_actions.load_project_action import show_project_in_panel
 

--- a/qaequilibrae/modules/processing_provider/model_building/create_empty_project.py
+++ b/qaequilibrae/modules/processing_provider/model_building/create_empty_project.py
@@ -2,7 +2,7 @@ import importlib.util as iutil
 from os import listdir, rmdir
 from os.path import isdir, join
 
-from qgis.core import QgsProcessingAlgorithm, QgsProcessingException
+from qgis.core import Qgis, QgsProcessingAlgorithm, QgsProcessingException
 from qgis.core import QgsProcessingParameterFile, QgsProcessingParameterString
 
 from qaequilibrae.i18n.translate import trlt
@@ -30,6 +30,10 @@ class CreateEmptyProject(QgsProcessingAlgorithm):
         self.addParameter(
             QgsProcessingParameterString(self.MODEL_NAME, self.tr("Model name"), defaultValue="new model")
         )
+
+    def flags(self):
+        # Filling the panel means touching widgets, which only the main thread may do
+        return super().flags() | Qgis.ProcessingAlgorithmFlag.NoThreading
 
     def processAlgorithm(self, parameters, context, feedback):
         parent_folder = self.parameterAsFile(parameters, self.PARENT_FOLDER, context)
@@ -81,13 +85,35 @@ class CreateEmptyProject(QgsProcessingAlgorithm):
         modes = list(project.network.modes.all_modes().keys())
         link_types = list(project.network.link_types.all_types().keys())
 
-        project.close()
-
         feedback.pushInfo(self.tr("Project created in ") + project_folder)
         feedback.pushInfo(self.tr("Default modes: ") + ", ".join(sorted(modes)))
         feedback.pushInfo(self.tr("Default link types: ") + ", ".join(sorted(link_types)))
 
+        self.show_in_panel(project, project_folder, feedback)
+
         return {"Output": project_folder}
+
+    def show_in_panel(self, project, project_folder, feedback):
+        """Hands the new model to the panel, the way every other way of creating one does.
+        """
+        from qaequilibrae import get_aequilibrae_menu_instance
+        from qaequilibrae.modules.menu_actions.load_project_action import show_project_in_panel
+
+        qgis_project = get_aequilibrae_menu_instance()
+
+        # Processing also runs with no plugin around it, as it does under the test suite
+        if qgis_project is None:
+            project.close()
+            return
+
+        # The panel holds one project at a time, and the one already open stays
+        if qgis_project.project is not None:
+            feedback.pushWarning(self.tr("Close the open project to see the new one in the panel"))
+            project.close()
+            return
+
+        qgis_project.project = project
+        show_project_in_panel(qgis_project, project_folder)
 
     def name(self):
         return "create_empty_project"

--- a/qaequilibrae/modules/processing_provider/model_building/create_empty_project.py
+++ b/qaequilibrae/modules/processing_provider/model_building/create_empty_project.py
@@ -100,7 +100,7 @@ class CreateEmptyProject(QgsProcessingAlgorithm):
 
         qgis_project = get_aequilibrae_menu_instance()
 
-        # Processing also runs with no plugin around it, as it does under the test suite
+        # Processing also runs with no plugin around it
         if qgis_project is None:
             project.close()
             return

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -102,12 +102,17 @@ def ae(qgis_iface) -> AequilibraEMenu:
 
 
 @pytest.fixture(scope="function")
-def ae_with_project(qgis_iface, folder_path) -> AequilibraEMenu:
+def sioux_falls_project_path(folder_path):
+    copytree("test/data/SiouxFalls_project", folder_path)
+    return folder_path
+
+
+@pytest.fixture(scope="function")
+def ae_with_project(qgis_iface, sioux_falls_project_path) -> AequilibraEMenu:
     ae = AequilibraEMenu(qgis_iface)
     from qaequilibrae.modules.menu_actions.load_project_action import _run_load_project_from_path
 
-    copytree("test/data/SiouxFalls_project", folder_path)
-    _run_load_project_from_path(ae, folder_path)
+    _run_load_project_from_path(ae, sioux_falls_project_path)
     yield ae
     ae.run_close_project()
     qgis_iface.messageBar().messages = {0: [], 1: [], 2: [], 3: []}

--- a/test/test_compare_scenarios.py
+++ b/test/test_compare_scenarios.py
@@ -5,7 +5,7 @@ from aequilibrae.distribution import Ipf
 from aequilibrae.paths import TrafficAssignment, TrafficClass
 from qgis.core import QgsProject
 
-from qaequilibrae.modules.gis.compare_scenarios_dialog import CompareScenariosDialog
+from qaequilibrae.modules.gis.compare_scenarios_dialog import CompareScenariosDialog, directional_field_pairs
 from qaequilibrae.modules.menu_actions.load_project_action import _run_load_project_from_path
 from .utilities import run_sfalls_assignment
 
@@ -41,6 +41,48 @@ def test_compare_scenarios(ae, model_path, composite):
     fields = ["base_matrix_ab", "base_matrix_ba", "alternative_matrix_ab", "alternative_matrix_ba"]
     for f in fields:
         assert f in field_names
+
+
+def test_directional_field_pairs():
+    """Result tables mix cases, and the pair has to come back spelled as the table spells it"""
+    fields = ["link_id", "matrix_ab", "matrix_ba", "matrix_tot", "VOC_AB", "VOC_BA", "VOC_max", "Preload_AB"]
+
+    assert dict(directional_field_pairs(fields)) == {
+        "matrix_*": ("matrix_ab", "matrix_ba"),
+        "VOC_*": ("VOC_AB", "VOC_BA"),
+    }, "a field without its counterpart, or without a direction at all, is not a pair"
+
+    # Paired on the suffix, so the "ab" in the middle of a class called "cab" is left alone
+    assert dict(directional_field_pairs(["cab_ab", "cab_ba"])) == {"cab_*": ("cab_ab", "cab_ba")}
+
+
+@pytest.mark.parametrize("field", ["matrix_*", "Preload_*", "Congested_Time_*", "VOC_*"])
+def test_compare_scenarios_on_every_offered_field(ae, model_path, field):
+    """Only the flow columns are lower case, and the rest used to reach the layer under a name
+    it did not carry - which surfaced as `evaluate()` handing back None to be read for `.real`."""
+    _run_load_project_from_path(ae, model_path)
+
+    dialog = CompareScenariosDialog(ae)
+    dialog.cob_alternative_result.setCurrentText("future_assignment")
+    dialog.cob_base_data.setCurrentText(field)
+    dialog.cob_alternative_data.setCurrentText(field)
+    assert dialog.cob_base_data.currentText() == field, "the field is not on offer"
+    base_pair = dialog.cob_base_data.currentData()
+    alter_pair = dialog.cob_alternative_data.currentData()
+    dialog.radio_compo.setChecked(True)
+
+    dialog.execute_comparison()
+
+    link_layer = QgsProject.instance().mapLayersByName("scenario_comparison")[0]
+    names = link_layer.fields().names()
+    # Read off the combo rather than off the label, since the label is the one thing that does
+    # not have to match the column - which is exactly what went wrong here
+    for prefix, pair in [("base", base_pair), ("alternative", alter_pair)]:
+        for column in pair:
+            assert f"{prefix}_{column}" in names
+
+    # The bandwidths only get built once the maximum is known, so the styling is the proof
+    assert link_layer.renderer().symbol().symbolLayerCount() > 1
 
 
 def future_assignment(aeq_from_qgis):

--- a/test/test_compare_scenarios.py
+++ b/test/test_compare_scenarios.py
@@ -58,8 +58,7 @@ def test_directional_field_pairs():
 
 @pytest.mark.parametrize("field", ["matrix_*", "Preload_*", "Congested_Time_*", "VOC_*"])
 def test_compare_scenarios_on_every_offered_field(ae, model_path, field):
-    """Only the flow columns are lower case, and the rest used to reach the layer under a name
-    it did not carry - which surfaced as `evaluate()` handing back None to be read for `.real`."""
+    """Only the flow columns are lower case; the rest used to reach the layer under a name it did not carry."""
     _run_load_project_from_path(ae, model_path)
 
     dialog = CompareScenariosDialog(ae)
@@ -75,8 +74,7 @@ def test_compare_scenarios_on_every_offered_field(ae, model_path, field):
 
     link_layer = QgsProject.instance().mapLayersByName("scenario_comparison")[0]
     names = link_layer.fields().names()
-    # Read off the combo rather than off the label, since the label is the one thing that does
-    # not have to match the column - which is exactly what went wrong here
+    # Off the combo, not the label: the label is the one thing that need not match the column
     for prefix, pair in [("base", base_pair), ("alternative", alter_pair)]:
         for column in pair:
             assert f"{prefix}_{column}" in names

--- a/test/test_processing_provider.py
+++ b/test/test_processing_provider.py
@@ -195,8 +195,19 @@ def test_create_empty_project_defaults_the_model_name():
     assert action.parameterDefinition("MODEL_NAME").defaultValue() == "new model"
 
 
+@pytest.fixture
+def no_menu_instance():
+    """Runs an algorithm the way Processing does with the plugin absent, whatever ran before"""
+    from qaequilibrae import get_aequilibrae_menu_instance, set_aequilibrae_menu_instance
+
+    previous = get_aequilibrae_menu_instance()
+    set_aequilibrae_menu_instance(None)
+    yield
+    set_aequilibrae_menu_instance(previous)
+
+
 @pytest.mark.parametrize("pre_create_folder", [True, False])
-def test_create_empty_project(tmp_path, pre_create_folder):
+def test_create_empty_project(no_menu_instance, tmp_path, pre_create_folder):
     parent_folder = str(tmp_path)
     project_folder = join(parent_folder, "new model")
 
@@ -226,6 +237,40 @@ def test_create_empty_project(tmp_path, pre_create_folder):
     assert len(project.network.link_types.all_types()) > 0
 
     project.close()
+
+
+def test_create_empty_project_shows_in_the_panel(ae, tmp_path):
+    """A model created from scratch reaches the panel, like every other way of creating one"""
+    parameters = {"PARENT_FOLDER": str(tmp_path), "MODEL_NAME": "new model"}
+
+    action = CreateEmptyProject()
+    action.initAlgorithm()
+
+    results, ok = action.run(parameters, QgsProcessingContext(), QgsProcessingFeedback())
+    assert ok
+
+    assert str(ae.project.project_base_path) == results["Output"]
+    assert ae.available_scenarios == ["root"]
+    assert {"links", "nodes", "zones"} <= set(ae.layers)
+    assert ae.projectManager.count() == 1
+
+    ae.run_close_project()
+
+
+def test_create_empty_project_leaves_the_open_project_alone(ae_with_project, tmp_path):
+    """The panel holds one project at a time, so the new model is only created on disk"""
+    in_the_panel = ae_with_project.project
+
+    parameters = {"PARENT_FOLDER": str(tmp_path), "MODEL_NAME": "new model"}
+
+    action = CreateEmptyProject()
+    action.initAlgorithm()
+
+    results, ok = action.run(parameters, QgsProcessingContext(), QgsProcessingFeedback())
+    assert ok
+    assert isfile(join(results["Output"], "project_database.sqlite"))
+
+    assert ae_with_project.project is in_the_panel
 
 
 def test_create_empty_project_on_populated_folder(tmp_path):

--- a/test/test_processing_provider.py
+++ b/test/test_processing_provider.py
@@ -197,7 +197,7 @@ def test_create_empty_project_defaults_the_model_name():
 
 @pytest.fixture
 def no_menu_instance():
-    """Runs an algorithm the way Processing does with the plugin absent, whatever ran before"""
+    """Runs an algorithm with no plugin instance, whatever ran before."""
     from qaequilibrae import get_aequilibrae_menu_instance, set_aequilibrae_menu_instance
 
     previous = get_aequilibrae_menu_instance()
@@ -240,7 +240,7 @@ def test_create_empty_project(no_menu_instance, tmp_path, pre_create_folder):
 
 
 def test_create_empty_project_shows_in_the_panel(ae, tmp_path):
-    """A model created from scratch reaches the panel, like every other way of creating one"""
+    """A model created from scratch reaches the panel."""
     parameters = {"PARENT_FOLDER": str(tmp_path), "MODEL_NAME": "new model"}
 
     action = CreateEmptyProject()
@@ -258,7 +258,7 @@ def test_create_empty_project_shows_in_the_panel(ae, tmp_path):
 
 
 def test_create_empty_project_leaves_the_open_project_alone(ae_with_project, tmp_path):
-    """The panel holds one project at a time, so the new model is only created on disk"""
+    """The panel holds one project at a time, so the new model is only created on disk."""
     in_the_panel = ae_with_project.project
 
     parameters = {"PARENT_FOLDER": str(tmp_path), "MODEL_NAME": "new model"}

--- a/test/test_scenario_project_path.py
+++ b/test/test_scenario_project_path.py
@@ -3,6 +3,19 @@ from pathlib import Path
 from qaequilibrae.modules.menu_actions.load_project_action import _project_root, _run_load_project_from_path
 
 
+def test_failed_load_does_not_claim_project_is_open(ae, tmp_path, sioux_falls_project_path):
+    _run_load_project_from_path(ae, str(tmp_path / "missing"))
+
+    assert ae.project is None
+
+    # The failed attempt must not prevent the user from opening a valid project next.
+    try:
+        _run_load_project_from_path(ae, sioux_falls_project_path)
+        assert ae.project is not None
+    finally:
+        ae.run_close_project()
+
+
 def test_base_path_is_root_while_scenario_is_active(sf_project):
     root = Path(sf_project.project.project_base_path)
 

--- a/test/test_scenario_project_path.py
+++ b/test/test_scenario_project_path.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from qaequilibrae.modules.menu_actions.load_project_action import _project_root, _run_load_project_from_path
 
 
@@ -14,6 +16,29 @@ def test_failed_load_does_not_claim_project_is_open(ae, tmp_path, sioux_falls_pr
         assert ae.project is not None
     finally:
         ae.run_close_project()
+
+
+def test_failed_panel_setup_does_not_leave_project_open(ae, sioux_falls_project_path, mocker):
+    def fail_after_changing_panel(qgis_project, _):
+        qgis_project.cob_scenarios.addItem("partial")
+        qgis_project.available_scenarios.append("partial")
+        qgis_project.matrices["partial"] = None
+        qgis_project.layers["partial"] = None
+        raise RuntimeError("panel setup failed")
+
+    mocker.patch(
+        "qaequilibrae.modules.menu_actions.load_project_action.show_project_in_panel",
+        side_effect=fail_after_changing_panel,
+    )
+
+    with pytest.raises(RuntimeError, match="panel setup failed"):
+        _run_load_project_from_path(ae, sioux_falls_project_path)
+
+    assert ae.project is None
+    assert ae.cob_scenarios.count() == 0
+    assert ae.available_scenarios == []
+    assert ae.matrices == {}
+    assert ae.layers == {}
 
 
 def test_base_path_is_root_while_scenario_is_active(sf_project):

--- a/test/test_traffic_assignment.py
+++ b/test/test_traffic_assignment.py
@@ -6,7 +6,7 @@ import openmatrix as omx
 import pandas as pd
 import pytest
 import yaml
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import Qt, QItemSelectionModel
 
 from qaequilibrae.modules.paths_procedures.traffic_assignment_dialog import TrafficAssignmentDialog
 
@@ -483,7 +483,7 @@ def test_multiclass(sf_project, qtbot, mocker):
     with sf_project.project.results_connection as conn:
         assert conn.execute(f"SELECT ROUND(SUM(PCE_tot), 4) FROM {test_name}").fetchone()[0] > 0
         assert conn.execute(f"SELECT ROUND(SUM(car_tot), 4) FROM {test_name}").fetchone()[0] > 0
-        assert conn.execute(f"SELECT ROUND(SUM(motorcycle_tot), 4) FROM {test_name}").fetchone()[0] > 0
+        assert conn.execute(f"SELECT ROUND(SUM(motorcycles_tot), 4) FROM {test_name}").fetchone()[0] > 0
         assert conn.execute(f"SELECT ROUND(SUM(trucks_tot), 4) FROM {test_name}").fetchone()[0] > 0
 
     pth = dialog.project.project_base_path
@@ -535,7 +535,7 @@ def test_all_or_nothing(sf_project, qtbot):
 
     # Assert we have a non-null result and that results are actually stored in the file
     with sf_project.project.results_connection as conn:
-        assert conn.execute(f"SELECT ROUND(SUM(matrix_tot), 4) FROM {test_name}").fetchone()[0] == 885_300.0
+        assert conn.execute(f"SELECT ROUND(SUM(car_tot), 4) FROM {test_name}").fetchone()[0] == 885_300.0
 
     pth = dialog.project.project_base_path
     skims = pth / "matrices" / f"{test_name}_car.omx"
@@ -960,3 +960,123 @@ def test_single_class_from_python(sf_project, qtbot, mocker):
         assert round(np.sum(np.nan_to_num(omx_file["free_flow_time_blended"][:])), 4) > 0
         assert round(np.sum(np.nan_to_num(omx_file["distance_final"][:])), 4) > 0
         assert round(np.sum(np.nan_to_num(omx_file["distance_blended"][:])), 4) > 0
+
+
+def add_class(dialog, qtbot, matrix, rows, name, mode_index=0):
+    """Fills the class form and clicks Add, the way a user builds one"""
+    dialog.cob_matrices.setCurrentText(matrix)
+    table = dialog.tbl_core_list
+    table.clearSelection()
+    flags = QItemSelectionModel.SelectionFlag.Select | QItemSelectionModel.SelectionFlag.Rows
+    for row in rows:
+        table.selectionModel().select(table.model().index(row, 0), flags)
+    dialog.cob_mode_for_class.setCurrentIndex(mode_index)
+    dialog.ln_class_name.setText(name)
+    dialog.pce_setter.setValue(1.0)
+    dialog.chb_check_centroids.setChecked(False)
+    qtbot.mouseClick(dialog.but_add_class, Qt.MouseButton.LeftButton)
+
+
+def test_classes_reading_cores_of_the_same_name(sf_project, qtbot):
+    """Both SiouxFalls demand matrices carry a core called `matrix`, which used to leave the two
+    classes writing the same result columns - and only saying so once the assignment had run."""
+    dialog = TrafficAssignmentDialog(sf_project)
+
+    add_class(dialog, qtbot, "demand", [0], "car")
+    add_class(dialog, qtbot, "demand_omx", [0], "van", mode_index=4)
+
+    assert dialog.class_cores == {"car": ["matrix"], "van": ["matrix"]}, "the cores picked are not remembered"
+    assert dialog.traffic_classes["car"].matrix.view_names == ["car"]
+    assert dialog.traffic_classes["van"].matrix.view_names == ["van"]
+
+    dialog.output_scenario_name.setText(f"TestSameCore_{uuid4().hex[:6]}")
+    assert dialog.check_data(), dialog.error
+
+    dialog.close()
+
+
+def test_a_class_reading_several_cores_prefixes_them(sf_project, qtbot):
+    """One name is not enough to tell several cores apart, so those keep theirs behind the class"""
+    dialog = TrafficAssignmentDialog(sf_project)
+
+    add_class(dialog, qtbot, "demand_mc", [0, 1], "car")
+
+    assert dialog.class_cores["car"] == ["car", "motorcycle"]
+    assert dialog.traffic_classes["car"].matrix.view_names == ["car_car", "car_motorcycle"]
+
+    dialog.close()
+
+
+def test_class_name_reused_or_empty_is_refused(sf_project, qtbot):
+    """The result columns are named after the class, so it has to be there and it has to be its own"""
+    dialog = TrafficAssignmentDialog(sf_project)
+
+    add_class(dialog, qtbot, "demand", [0], "car")
+    first = dialog.traffic_classes["car"]
+    add_class(dialog, qtbot, "demand_omx", [0], "car", mode_index=4)
+
+    assert list(dialog.traffic_classes) == ["car"]
+    assert dialog.class_cores["car"] == ["matrix"]
+    assert dialog.traffic_classes["car"] is first, "the second class overwrote the first"
+
+    add_class(dialog, qtbot, "demand_omx", [0], "", mode_index=4)
+
+    assert list(dialog.traffic_classes) == ["car"]
+
+    dialog.close()
+
+
+def test_check_data_catches_result_fields_that_meet_in_the_middle(sf_project, qtbot):
+    """Unique class names normally settle it, but two prefixed names can still land on the same
+    string - and the assignment is far too long a wait for that to surface at save time."""
+    dialog = TrafficAssignmentDialog(sf_project)
+
+    add_class(dialog, qtbot, "demand_mc", [0, 1], "car")
+    add_class(dialog, qtbot, "demand_mc", [0], "car_car", mode_index=4)
+
+    dialog.output_scenario_name.setText(f"TestCollision_{uuid4().hex[:6]}")
+
+    assert not dialog.check_data()
+    assert "car_car" in dialog.error
+
+    dialog.close()
+
+
+def test_yaml_carries_the_core_the_matrix_knows(sf_project, qtbot, mocker):
+    """The class relabels its computational view, so the config has to come from what the user
+    picked - a core named after the class is not one the matrix could be asked for again."""
+    saved_yaml = f"{sf_project.project.project_base_path}/same_core_config.yml"
+    mocker.patch(
+        "qaequilibrae.modules.paths_procedures.traffic_assignment_dialog.TrafficAssignmentDialog._browse_yaml_path",
+        return_value=saved_yaml,
+    )
+
+    dialog = TrafficAssignmentDialog(sf_project)
+
+    add_class(dialog, qtbot, "demand", [0], "car")
+    add_class(dialog, qtbot, "demand_omx", [0], "van", mode_index=4)
+
+    dialog.output_scenario_name.setText("result_same_core")
+    dialog.cob_vdf.setCurrentText("bpr")
+    dialog.tbl_vdf_parameters.cellWidget(0, 1).setText("0.15")
+    dialog.tbl_vdf_parameters.cellWidget(1, 1).setText("4.0")
+    dialog.cob_capacity.setCurrentText("capacity")
+    dialog.cob_ffttime.setCurrentText("free_flow_time")
+
+    qtbot.mouseClick(dialog.but_save_yaml, Qt.MouseButton.LeftButton)
+    dialog.close()
+
+    with open(saved_yaml, "r") as f:
+        saved = yaml.safe_load(f)
+
+    cores = {name: cfg["matrix_core"] for entry in saved["traffic_classes"] for name, cfg in entry.items()}
+    assert cores == {"car": "matrix", "van": "matrix"}
+
+    # Which is the half that matters: the config has to be loadable again
+    reopened = TrafficAssignmentDialog(sf_project)
+    qtbot.mouseClick(reopened.but_load_yaml, Qt.MouseButton.LeftButton)
+
+    assert reopened.class_cores == {"car": ["matrix"], "van": ["matrix"]}
+    assert reopened.traffic_classes["van"].matrix.view_names == ["van"]
+
+    reopened.close()

--- a/test/test_traffic_assignment.py
+++ b/test/test_traffic_assignment.py
@@ -963,7 +963,7 @@ def test_single_class_from_python(sf_project, qtbot, mocker):
 
 
 def add_class(dialog, qtbot, matrix, rows, name, mode_index=0):
-    """Fills the class form and clicks Add, the way a user builds one"""
+    """Fills the class form and clicks Add."""
     dialog.cob_matrices.setCurrentText(matrix)
     table = dialog.tbl_core_list
     table.clearSelection()
@@ -978,8 +978,7 @@ def add_class(dialog, qtbot, matrix, rows, name, mode_index=0):
 
 
 def test_classes_reading_cores_of_the_same_name(sf_project, qtbot):
-    """Both SiouxFalls demand matrices carry a core called `matrix`, which used to leave the two
-    classes writing the same result columns - and only saying so once the assignment had run."""
+    """Both SiouxFalls demand matrices carry a core called `matrix`, which used to collide at save time."""
     dialog = TrafficAssignmentDialog(sf_project)
 
     add_class(dialog, qtbot, "demand", [0], "car")
@@ -996,7 +995,7 @@ def test_classes_reading_cores_of_the_same_name(sf_project, qtbot):
 
 
 def test_a_class_reading_several_cores_prefixes_them(sf_project, qtbot):
-    """One name is not enough to tell several cores apart, so those keep theirs behind the class"""
+    """A class reading several cores keeps each core name behind the class name."""
     dialog = TrafficAssignmentDialog(sf_project)
 
     add_class(dialog, qtbot, "demand_mc", [0, 1], "car")
@@ -1007,44 +1006,53 @@ def test_a_class_reading_several_cores_prefixes_them(sf_project, qtbot):
     dialog.close()
 
 
-def test_class_name_reused_or_empty_is_refused(sf_project, qtbot):
-    """The result columns are named after the class, so it has to be there and it has to be its own"""
+@pytest.mark.parametrize("second_name", ["car", "CAR", "  car  ", "   "])
+def test_class_name_reused_or_empty_is_refused(sf_project, qtbot, second_name):
+    """The class names the result columns, so it must be present and unique down to a fold."""
     dialog = TrafficAssignmentDialog(sf_project)
 
     add_class(dialog, qtbot, "demand", [0], "car")
     first = dialog.traffic_classes["car"]
-    add_class(dialog, qtbot, "demand_omx", [0], "car", mode_index=4)
+
+    add_class(dialog, qtbot, "demand_omx", [0], second_name, mode_index=4)
 
     assert list(dialog.traffic_classes) == ["car"]
     assert dialog.class_cores["car"] == ["matrix"]
     assert dialog.traffic_classes["car"] is first, "the second class overwrote the first"
 
-    add_class(dialog, qtbot, "demand_omx", [0], "", mode_index=4)
+    dialog.close()
+
+
+def test_class_name_is_stripped(sf_project, qtbot):
+    """Blanks around the name would follow it into the result column names"""
+    dialog = TrafficAssignmentDialog(sf_project)
+
+    add_class(dialog, qtbot, "demand", [0], "  car  ")
 
     assert list(dialog.traffic_classes) == ["car"]
+    assert dialog.traffic_classes["car"].matrix.view_names == ["car"]
 
     dialog.close()
 
 
-def test_check_data_catches_result_fields_that_meet_in_the_middle(sf_project, qtbot):
-    """Unique class names normally settle it, but two prefixed names can still land on the same
-    string - and the assignment is far too long a wait for that to surface at save time."""
+@pytest.mark.parametrize("colliding_name", ["car_car", "Car_Car"])
+def test_check_data_catches_result_fields_that_meet_in_the_middle(sf_project, qtbot, colliding_name):
+    """Unique class names are not enough: two prefixed names can still land on the same string."""
     dialog = TrafficAssignmentDialog(sf_project)
 
     add_class(dialog, qtbot, "demand_mc", [0, 1], "car")
-    add_class(dialog, qtbot, "demand_mc", [0], "car_car", mode_index=4)
+    add_class(dialog, qtbot, "demand_mc", [0], colliding_name, mode_index=4)
 
     dialog.output_scenario_name.setText(f"TestCollision_{uuid4().hex[:6]}")
 
     assert not dialog.check_data()
-    assert "car_car" in dialog.error
+    assert colliding_name in dialog.error
 
     dialog.close()
 
 
 def test_yaml_carries_the_core_the_matrix_knows(sf_project, qtbot, mocker):
-    """The class relabels its computational view, so the config has to come from what the user
-    picked - a core named after the class is not one the matrix could be asked for again."""
+    """The class relabels its view, so the config has to record the core the user actually picked."""
     saved_yaml = f"{sf_project.project.project_base_path}/same_core_config.yml"
     mocker.patch(
         "qaequilibrae.modules.paths_procedures.traffic_assignment_dialog.TrafficAssignmentDialog._browse_yaml_path",

--- a/test/test_traffic_assignment.py
+++ b/test/test_traffic_assignment.py
@@ -1063,6 +1063,7 @@ def test_yaml_carries_the_core_the_matrix_knows(sf_project, qtbot, mocker):
 
     add_class(dialog, qtbot, "demand", [0], "car")
     add_class(dialog, qtbot, "demand_omx", [0], "van", mode_index=4)
+    add_class(dialog, qtbot, "demand_mc", [0, 1], "multi", mode_index=4)
 
     dialog.output_scenario_name.setText("result_same_core")
     dialog.cob_vdf.setCurrentText("bpr")
@@ -1077,14 +1078,16 @@ def test_yaml_carries_the_core_the_matrix_knows(sf_project, qtbot, mocker):
     with open(saved_yaml, "r") as f:
         saved = yaml.safe_load(f)
 
-    cores = {name: cfg["matrix_core"] for entry in saved["traffic_classes"] for name, cfg in entry.items()}
+    configs = {name: cfg for entry in saved["traffic_classes"] for name, cfg in entry.items()}
+    cores = {name: cfg["matrix_core"] for name, cfg in configs.items() if name != "multi"}
     assert cores == {"car": "matrix", "van": "matrix"}
+    assert configs["multi"]["matrix_cores"] == ["car", "motorcycle"]
 
     # Which is the half that matters: the config has to be loadable again
     reopened = TrafficAssignmentDialog(sf_project)
     qtbot.mouseClick(reopened.but_load_yaml, Qt.MouseButton.LeftButton)
 
-    assert reopened.class_cores == {"car": ["matrix"], "van": ["matrix"]}
+    assert reopened.class_cores == {"car": ["matrix"], "van": ["matrix"], "multi": ["car", "motorcycle"]}
     assert reopened.traffic_classes["van"].matrix.view_names == ["van"]
 
     reopened.close()


### PR DESCRIPTION
1. A project created from scratch showed no layers in the panel

Every project-creation path handed the new project to the panel except the Processing algorithm Create empty project, which created the folder and closed the project immediately. The panel kept showing whatever it had before, so the new model's layers were nowhere to be found.

2. Two traffic classes reading matrix cores of the same name killed the assignment

Result columns are named after the matrix core, not the traffic class. Two classes reading cores of the same name — two matrices both carrying a core called matrix is routine — produced duplicate columns, and saving died with duplicate column name: matrix_ab. It failed at save time, with the whole assignment already run, inside a Qt slot with no handler. The "class name already used" guard was also missing its return, so class names were never actually unique.

3. Scenario comparison crashed on every field except the flow columns

AttributeError: 'NoneType' object has no attribute 'real'. The field list was lower-cased for the dropdown while the result table keeps its real column names, and AequilibraE capitalises everything it computes itself (Preload_AB, VOC_AB, Congested_Time_AB). The case-sensitive match never found them, so no data field reached the layer, QgsExpression.evaluate() returned NULL, and reading .real off it blew up. Only the flow columns — lower-case, named after matrix cores — ever worked.

4. Class names differing only by case hit the same wall as #2 (from review)

SQLite rejects two columns that differ only by case, so classes named car and Car passed every guard and then failed at save time — the same failure #2 set out to remove. Whitespace-only names also slipped through the emptiness check.