### PR TITLE
Remove qtbot and waits

### DIFF
--- a/test/test_qaequilibrae_menu_with_project.py
+++ b/test/test_qaequilibrae_menu_with_project.py
@@ -1,30 +1,16 @@
 import pytest
 import sys
-from qgis.PyQt.QtCore import QTimer
-from qgis.PyQt.QtWidgets import QApplication
 
 
 pytestmark = pytest.mark.skipif(sys.platform.startswith("win"), reason="Running on Windows")
 
 
-def wait_for_active_window(qtbot):
-    timeout = 3000
-    window = QApplication.activeWindow()
-    while window is None and timeout > 0:
-        window = QApplication.activeWindow()
-        qtbot.wait(100)
-        timeout -= 100
-    assert timeout > 0, "Waiting for window to open timed out after 3 seconds"
-    return window
-
-
-def check_if_new_active_window_matches_class(qtbot, windowClass):
-    dialog = wait_for_active_window(qtbot)
-    try:
-        assert isinstance(dialog, windowClass), "Active window does not match the correct window class"
-    finally:
+def mock_dialog_exec(mocker, dialog_class):
+    def handle_exec(dialog):
+        assert isinstance(dialog, dialog_class), "Dialog does not have the correct class"
         dialog.close()
-        assert QApplication.activeWindow() is None, "Dialog window did not close properly"
+
+    mocker.patch.object(dialog_class, "exec", autospec=True, side_effect=handle_exec)
 
 
 def test_load_project(ae_with_project):
@@ -33,85 +19,67 @@ def test_load_project(ae_with_project):
     assert ae_with_project.project is not None, "project should be loaded"
 
 
-def test_run_module_menu(coquimbo_project, qtbot):
+def test_run_module_menu(coquimbo_project, mocker):
     from qaequilibrae.modules.project_procedures import RunModuleDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, RunModuleDialog)
 
     action = coquimbo_project.menuActions["Project"][1]
     assert action.text() == "Run procedures", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, RunModuleDialog)
     action.trigger()
     messagebar = coquimbo_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_scenarios_menu(ae_with_project, qtbot):
+def test_scenarios_menu(ae_with_project, mocker):
     from qaequilibrae.modules.project_procedures import CreateScenariosDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, CreateScenariosDialog)
 
     action = ae_with_project.menuActions["Project"][2]
     assert action.text() == "Scenarios", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, CreateScenariosDialog)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_trip_distribution_menu(ae_with_project, qtbot):
+def test_trip_distribution_menu(ae_with_project, mocker):
     from qaequilibrae.modules.distribution_procedures import DistributionModelsDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, DistributionModelsDialog)
 
     action = ae_with_project.menuActions["Trip distribution"][0]
     assert action.text() == "Trip distribution", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, DistributionModelsDialog)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_shortest_path_menu(ae_with_project, qtbot):
+def test_shortest_path_menu(ae_with_project, mocker):
     from qaequilibrae.modules.paths_procedures.show_shortest_path_dialog import ShortestPathDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, ShortestPathDialog)
 
     action = ae_with_project.menuActions["Path computation"][0]
     assert action.text() == "Shortest path", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, ShortestPathDialog)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_impedance_matrix_menu(ae_with_project, qtbot):
+def test_impedance_matrix_menu(ae_with_project, mocker):
     from qaequilibrae.modules.paths_procedures.impedance_matrix_dialog import ImpedanceMatrixDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, ImpedanceMatrixDialog)
 
     action = ae_with_project.menuActions["Path computation"][1]
     assert action.text() == "Impedance matrix", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, ImpedanceMatrixDialog)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_skim_viewer_menu(ae_with_project, qtbot):
+def test_skim_viewer_menu(ae_with_project, mocker):
     from qaequilibrae.modules.paths_procedures.skim_viewer_dialog import SkimViewerDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, SkimViewerDialog)
 
     action = ae_with_project.menuActions["Path computation"][2]
     assert action.text() == "Skim viewer", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, SkimViewerDialog)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert messagebar.messages[2][0] == "Input error:Please set an active layer to proceed", (
@@ -119,105 +87,84 @@ def test_skim_viewer_menu(ae_with_project, qtbot):
     )
 
 
-def test_traffic_assignment_menu(ae_with_project, qtbot):
+def test_traffic_assignment_menu(ae_with_project, mocker):
     from qaequilibrae.modules.paths_procedures.traffic_assignment_dialog import TrafficAssignmentDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, TrafficAssignmentDialog)
 
     action = ae_with_project.menuActions["Traffic assignment"][0]
     assert action.text() == "Traffic assignment", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, TrafficAssignmentDialog)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_route_choice_menu(ae_with_project, qtbot):
+def test_route_choice_menu(ae_with_project, mocker):
     from qaequilibrae.modules.paths_procedures.route_choice_dialog import RouteChoiceDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, RouteChoiceDialog)
 
     action = ae_with_project.menuActions["Route choice"][0]
     assert action.text() == "Route choice", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, RouteChoiceDialog)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_display_project_data_menu(ae_with_project, qtbot):
+def test_display_project_data_menu(ae_with_project, mocker):
     from qaequilibrae.modules.matrix_procedures import LoadProjectDataDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, LoadProjectDataDialog)
 
     action = ae_with_project.menuActions["Mapping"][0]
     assert action.text() == "Visualize data", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, LoadProjectDataDialog)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_gis_desire_lines_menu(ae_with_project, qtbot):
+def test_gis_desire_lines_menu(ae_with_project, mocker):
     from qaequilibrae.modules.gis.desire_lines_dialog import DesireLinesDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, DesireLinesDialog)
 
     action = ae_with_project.menuActions["Mapping"][1]
     assert action.text() == "Desire lines", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, DesireLinesDialog)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_gis_stacked_bandwidth_menu(ae_with_project, qtbot):
+def test_gis_stacked_bandwidth_menu(ae_with_project, mocker):
     from qaequilibrae.modules.gis import CreateBandwidthsDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, CreateBandwidthsDialog)
 
     action = ae_with_project.menuActions["Mapping"][2]
     assert action.text() == "Stacked bandwidth", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, CreateBandwidthsDialog)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_gis_scenario_comparison_menu(ae_with_project, qtbot):
+def test_gis_scenario_comparison_menu(ae_with_project, mocker):
     from qaequilibrae.modules.gis import CompareScenariosDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, CompareScenariosDialog)
 
     action = ae_with_project.menuActions["Mapping"][3]
     assert action.text() == "Scenario comparison", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, CompareScenariosDialog)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_gtfs_importer(ae_with_project, qtbot):
+def test_gtfs_importer(ae_with_project, mocker):
     from qaequilibrae.modules.transit_procedures.gtfs_importer import GTFSImporter
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, GTFSImporter)
 
     action = ae_with_project.menuActions["Transit"][0]
     assert action.text() == "Import GTFS", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, GTFSImporter)
     action.trigger()
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_gtfs_explorer(sf_project, qtbot):
+def test_gtfs_explorer(sf_project):
     action = sf_project.menuActions["Transit"][2]
     assert action.text() == "Explore transit", "Wrong text content"
     action.trigger()

--- a/test/test_qaequilibrae_menu_with_project.py
+++ b/test/test_qaequilibrae_menu_with_project.py
@@ -1,16 +1,44 @@
+from contextlib import contextmanager
+
 import pytest
 import sys
+from qgis.PyQt.QtCore import QEvent, QMetaObject, QObject, Qt
+from qgis.PyQt.QtWidgets import QApplication
 
 
 pytestmark = pytest.mark.skipif(sys.platform.startswith("win"), reason="Running on Windows")
 
 
-def mock_dialog_exec(mocker, dialog_class):
-    def handle_exec(dialog):
-        assert isinstance(dialog, dialog_class), "Dialog does not have the correct class"
-        dialog.close()
+class DialogEventFilter(QObject):
+    def __init__(self, dialog_class):
+        super().__init__()
+        self.dialog_class = dialog_class
+        self.dialog = None
 
-    mocker.patch.object(dialog_class, "exec", autospec=True, side_effect=handle_exec)
+    def eventFilter(self, watched, event):
+        if self.dialog is None and event.type() == QEvent.Type.Show and isinstance(watched, self.dialog_class):
+            self.dialog = watched
+            QMetaObject.invokeMethod(watched, "accept", Qt.ConnectionType.QueuedConnection)
+        return super().eventFilter(watched, event)
+
+
+@contextmanager
+def close_dialog_in_event_loop(dialog_class):
+    dialog_filter = DialogEventFilter(dialog_class)
+    application = QApplication.instance()
+    application.installEventFilter(dialog_filter)
+    try:
+        yield dialog_filter
+    finally:
+        application.removeEventFilter(dialog_filter)
+
+
+def trigger_dialog_action(action, dialog_class):
+    with close_dialog_in_event_loop(dialog_class) as dialog_filter:
+        action.trigger()
+
+    assert isinstance(dialog_filter.dialog, dialog_class), "Dialog does not have the correct class"
+    assert dialog_filter.dialog.isVisible() is False, "Dialog did not close properly"
 
 
 def test_load_project(ae_with_project):
@@ -19,147 +47,134 @@ def test_load_project(ae_with_project):
     assert ae_with_project.project is not None, "project should be loaded"
 
 
-def test_run_module_menu(coquimbo_project, mocker):
+def test_run_module_menu(coquimbo_project):
     from qaequilibrae.modules.project_procedures import RunModuleDialog
 
     action = coquimbo_project.menuActions["Project"][1]
     assert action.text() == "Run procedures", "Wrong text content"
-    mock_dialog_exec(mocker, RunModuleDialog)
-    action.trigger()
+    trigger_dialog_action(action, RunModuleDialog)
     messagebar = coquimbo_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_scenarios_menu(ae_with_project, mocker):
+def test_scenarios_menu(ae_with_project):
     from qaequilibrae.modules.project_procedures import CreateScenariosDialog
 
     action = ae_with_project.menuActions["Project"][2]
     assert action.text() == "Scenarios", "Wrong text content"
-    mock_dialog_exec(mocker, CreateScenariosDialog)
-    action.trigger()
+    trigger_dialog_action(action, CreateScenariosDialog)
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_trip_distribution_menu(ae_with_project, mocker):
+def test_trip_distribution_menu(ae_with_project):
     from qaequilibrae.modules.distribution_procedures import DistributionModelsDialog
 
     action = ae_with_project.menuActions["Trip distribution"][0]
     assert action.text() == "Trip distribution", "Wrong text content"
-    mock_dialog_exec(mocker, DistributionModelsDialog)
-    action.trigger()
+    trigger_dialog_action(action, DistributionModelsDialog)
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_shortest_path_menu(ae_with_project, mocker):
+def test_shortest_path_menu(ae_with_project):
     from qaequilibrae.modules.paths_procedures.show_shortest_path_dialog import ShortestPathDialog
 
     action = ae_with_project.menuActions["Path computation"][0]
     assert action.text() == "Shortest path", "Wrong text content"
-    mock_dialog_exec(mocker, ShortestPathDialog)
-    action.trigger()
+    trigger_dialog_action(action, ShortestPathDialog)
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_impedance_matrix_menu(ae_with_project, mocker):
+def test_impedance_matrix_menu(ae_with_project):
     from qaequilibrae.modules.paths_procedures.impedance_matrix_dialog import ImpedanceMatrixDialog
 
     action = ae_with_project.menuActions["Path computation"][1]
     assert action.text() == "Impedance matrix", "Wrong text content"
-    mock_dialog_exec(mocker, ImpedanceMatrixDialog)
-    action.trigger()
+    trigger_dialog_action(action, ImpedanceMatrixDialog)
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_skim_viewer_menu(ae_with_project, mocker):
+def test_skim_viewer_menu(ae_with_project):
     from qaequilibrae.modules.paths_procedures.skim_viewer_dialog import SkimViewerDialog
 
     action = ae_with_project.menuActions["Path computation"][2]
     assert action.text() == "Skim viewer", "Wrong text content"
-    mock_dialog_exec(mocker, SkimViewerDialog)
-    action.trigger()
+    trigger_dialog_action(action, SkimViewerDialog)
     messagebar = ae_with_project.iface.messageBar()
     assert messagebar.messages[2][0] == "Input error:Please set an active layer to proceed", (
         "Level 2 error message is missing"
     )
 
 
-def test_traffic_assignment_menu(ae_with_project, mocker):
+def test_traffic_assignment_menu(ae_with_project):
     from qaequilibrae.modules.paths_procedures.traffic_assignment_dialog import TrafficAssignmentDialog
 
     action = ae_with_project.menuActions["Traffic assignment"][0]
     assert action.text() == "Traffic assignment", "Wrong text content"
-    mock_dialog_exec(mocker, TrafficAssignmentDialog)
-    action.trigger()
+    trigger_dialog_action(action, TrafficAssignmentDialog)
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_route_choice_menu(ae_with_project, mocker):
+def test_route_choice_menu(ae_with_project):
     from qaequilibrae.modules.paths_procedures.route_choice_dialog import RouteChoiceDialog
 
     action = ae_with_project.menuActions["Route choice"][0]
     assert action.text() == "Route choice", "Wrong text content"
-    mock_dialog_exec(mocker, RouteChoiceDialog)
-    action.trigger()
+    trigger_dialog_action(action, RouteChoiceDialog)
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_display_project_data_menu(ae_with_project, mocker):
+def test_display_project_data_menu(ae_with_project):
     from qaequilibrae.modules.matrix_procedures import LoadProjectDataDialog
 
     action = ae_with_project.menuActions["Mapping"][0]
     assert action.text() == "Visualize data", "Wrong text content"
-    mock_dialog_exec(mocker, LoadProjectDataDialog)
-    action.trigger()
+    trigger_dialog_action(action, LoadProjectDataDialog)
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_gis_desire_lines_menu(ae_with_project, mocker):
+def test_gis_desire_lines_menu(ae_with_project):
     from qaequilibrae.modules.gis.desire_lines_dialog import DesireLinesDialog
 
     action = ae_with_project.menuActions["Mapping"][1]
     assert action.text() == "Desire lines", "Wrong text content"
-    mock_dialog_exec(mocker, DesireLinesDialog)
-    action.trigger()
+    trigger_dialog_action(action, DesireLinesDialog)
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_gis_stacked_bandwidth_menu(ae_with_project, mocker):
+def test_gis_stacked_bandwidth_menu(ae_with_project):
     from qaequilibrae.modules.gis import CreateBandwidthsDialog
 
     action = ae_with_project.menuActions["Mapping"][2]
     assert action.text() == "Stacked bandwidth", "Wrong text content"
-    mock_dialog_exec(mocker, CreateBandwidthsDialog)
-    action.trigger()
+    trigger_dialog_action(action, CreateBandwidthsDialog)
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_gis_scenario_comparison_menu(ae_with_project, mocker):
+def test_gis_scenario_comparison_menu(ae_with_project):
     from qaequilibrae.modules.gis import CompareScenariosDialog
 
     action = ae_with_project.menuActions["Mapping"][3]
     assert action.text() == "Scenario comparison", "Wrong text content"
-    mock_dialog_exec(mocker, CompareScenariosDialog)
-    action.trigger()
+    trigger_dialog_action(action, CompareScenariosDialog)
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 
 
-def test_gtfs_importer(ae_with_project, mocker):
+def test_gtfs_importer(ae_with_project):
     from qaequilibrae.modules.transit_procedures.gtfs_importer import GTFSImporter
 
     action = ae_with_project.menuActions["Transit"][0]
     assert action.text() == "Import GTFS", "Wrong text content"
-    mock_dialog_exec(mocker, GTFSImporter)
-    action.trigger()
+    trigger_dialog_action(action, GTFSImporter)
     messagebar = ae_with_project.iface.messageBar()
     assert len(messagebar.messages[2]) == 0, "Messagebar should be empty" + str(messagebar.messages)
 

--- a/test/test_qaequilibrae_menu_without_project.py
+++ b/test/test_qaequilibrae_menu_without_project.py
@@ -1,44 +1,27 @@
 import pytest
 import sys
-from qgis.PyQt.QtCore import QTimer
-from qgis.PyQt.QtWidgets import QApplication
 
 
 pytestmark = pytest.mark.skipif(sys.platform.startswith("win"), reason="Running on Windows")
 
 
-def wait_for_active_window(qtbot):
-    timeout = 3000
-    window = QApplication.activeWindow()
-    while window is None and timeout > 0:
-        window = QApplication.activeWindow()
-        qtbot.wait(100)
-        timeout -= 100
-    assert timeout > 0, "Waiting for window to open timed out after 3 seconds"
-    return window
-
-
-def check_if_new_active_window_matches_class(qtbot, windowClass):
-    dialog = wait_for_active_window(qtbot)
-    try:
-        assert isinstance(dialog, windowClass), "Active window does not match the correct window class"
-    finally:
+def mock_dialog_exec(mocker, dialog_class):
+    def handle_exec(dialog):
+        assert isinstance(dialog, dialog_class), "Dialog does not have the correct class"
         dialog.close()
-        assert QApplication.activeWindow() is None, "Dialog window did not close properly"
+
+    mocker.patch.object(dialog_class, "exec", autospec=True, side_effect=handle_exec)
 
 
-def test_open_project_menu(ae, qtbot):
+def test_open_project_menu(ae):
     """Testing open project menu
     TODO: find a way to capture and close the open QFileDialog"""
-    # def handle_trigger():
-    #     check_if_new_active_window_matches_class(qtbot, QFileDialog)
     action = ae.menuActions["Project"][0]
     assert action.text() == "Open project", "Wrong text content"
-    # QTimer.singleShot(10, handle_trigger)
     # action.trigger()
 
 
-def test_run_module_menu(ae, qtbot):
+def test_run_module_menu(ae):
     action = next((a for a in ae.menuActions["Project"] if a.text() == "Run procedures"), None)
     assert action is not None, "Menu action 'Run procedures' not found"
     assert action.text() == "Run procedures", "Wrong text content"
@@ -47,7 +30,7 @@ def test_run_module_menu(ae, qtbot):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_scenarios_menu(ae, qtbot):
+def test_scenarios_menu(ae):
     action = next((a for a in ae.menuActions["Project"] if a.text() == "Scenarios"), None)
     assert action is not None, "Menu action 'Scenarios' not found"
     assert action.text() == "Scenarios", "Wrong text content"
@@ -56,7 +39,7 @@ def test_scenarios_menu(ae, qtbot):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_trip_distribution_menu(ae, qtbot):
+def test_trip_distribution_menu(ae):
     action = ae.menuActions["Trip distribution"][0]
     assert action.text() == "Trip distribution", "Wrong text content"
     action.trigger()
@@ -64,7 +47,7 @@ def test_trip_distribution_menu(ae, qtbot):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_shortest_path_menu(ae, qtbot):
+def test_shortest_path_menu(ae):
     action = ae.menuActions["Path computation"][0]
     assert action.text() == "Shortest path", "Wrong text content"
     action.trigger()
@@ -72,7 +55,7 @@ def test_shortest_path_menu(ae, qtbot):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_impedance_matrix_menu(ae, qtbot):
+def test_impedance_matrix_menu(ae):
     action = ae.menuActions["Path computation"][1]
     assert action.text() == "Impedance matrix", "Wrong text content"
     action.trigger()
@@ -80,7 +63,7 @@ def test_impedance_matrix_menu(ae, qtbot):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_skim_viewer_menu(ae, qtbot):
+def test_skim_viewer_menu(ae):
     action = ae.menuActions["Path computation"][2]
     assert action.text() == "Skim viewer", "Wrong text content"
     action.trigger()
@@ -88,7 +71,7 @@ def test_skim_viewer_menu(ae, qtbot):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_traffic_assignment_menu(ae, qtbot):
+def test_traffic_assignment_menu(ae):
     action = ae.menuActions["Traffic assignment"][0]
     assert action.text() == "Traffic assignment", "Wrong text content"
     action.trigger()
@@ -96,7 +79,7 @@ def test_traffic_assignment_menu(ae, qtbot):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_route_choice_menu(ae, qtbot):
+def test_route_choice_menu(ae):
     action = ae.menuActions["Route choice"][0]
     assert action.text() == "Route choice", "Wrong text content"
     action.trigger()
@@ -104,31 +87,25 @@ def test_route_choice_menu(ae, qtbot):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_gis_desire_lines_menu(ae, qtbot):
+def test_gis_desire_lines_menu(ae, mocker):
     from qaequilibrae.modules.gis.desire_lines_dialog import DesireLinesDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, DesireLinesDialog)
 
     action = ae.menuActions["Mapping"][1]
     assert action.text() == "Desire lines", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, DesireLinesDialog)
     action.trigger()
 
 
-def test_gis_stacked_bandwidth_menu(ae, qtbot):
+def test_gis_stacked_bandwidth_menu(ae, mocker):
     from qaequilibrae.modules.gis import CreateBandwidthsDialog
-
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, CreateBandwidthsDialog)
 
     action = ae.menuActions["Mapping"][2]
     assert action.text() == "Stacked bandwidth", "Wrong text content"
-    QTimer.singleShot(10, handle_trigger)
+    mock_dialog_exec(mocker, CreateBandwidthsDialog)
     action.trigger()
 
 
-def test_gis_scenario_comparison_menu(ae, qtbot):
+def test_gis_scenario_comparison_menu(ae):
     action = ae.menuActions["Mapping"][3]
     assert action.text() == "Scenario comparison", "Wrong text content"
     action.trigger()
@@ -136,13 +113,13 @@ def test_gis_scenario_comparison_menu(ae, qtbot):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_help_menu(ae, qtbot):
+def test_help_menu(ae):
     """TODO: find a way to capture the opening of webpage"""
     button = ae.menuActions["AequilibraE"][0]
     assert button.text() == "Help", "Wrong text content"
 
 
-def test_gtfs_importer(ae, qtbot):
+def test_gtfs_importer(ae):
     action = ae.menuActions["Transit"][0]
     assert action.text() == "Import GTFS", "Wrong text content"
     action.trigger()
@@ -150,7 +127,7 @@ def test_gtfs_importer(ae, qtbot):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_pt_skim_and_assign(ae, qtbot):
+def test_pt_skim_and_assign(ae):
     action = ae.menuActions["Transit"][1]
     assert action.text() == "Skimming and assignment", "Wrong text content"
     action.trigger()
@@ -158,7 +135,7 @@ def test_pt_skim_and_assign(ae, qtbot):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_gtfs_explorer(ae, qtbot):
+def test_gtfs_explorer(ae):
     action = ae.menuActions["Transit"][2]
     assert action.text() == "Explore transit", "Wrong text content"
     action.trigger()

--- a/test/test_qaequilibrae_menu_without_project.py
+++ b/test/test_qaequilibrae_menu_without_project.py
@@ -1,16 +1,44 @@
+from contextlib import contextmanager
+
 import pytest
 import sys
+from qgis.PyQt.QtCore import QEvent, QMetaObject, QObject, Qt
+from qgis.PyQt.QtWidgets import QApplication
 
 
 pytestmark = pytest.mark.skipif(sys.platform.startswith("win"), reason="Running on Windows")
 
 
-def mock_dialog_exec(mocker, dialog_class):
-    def handle_exec(dialog):
-        assert isinstance(dialog, dialog_class), "Dialog does not have the correct class"
-        dialog.close()
+class DialogEventFilter(QObject):
+    def __init__(self, dialog_class):
+        super().__init__()
+        self.dialog_class = dialog_class
+        self.dialog = None
 
-    mocker.patch.object(dialog_class, "exec", autospec=True, side_effect=handle_exec)
+    def eventFilter(self, watched, event):
+        if self.dialog is None and event.type() == QEvent.Type.Show and isinstance(watched, self.dialog_class):
+            self.dialog = watched
+            QMetaObject.invokeMethod(watched, "accept", Qt.ConnectionType.QueuedConnection)
+        return super().eventFilter(watched, event)
+
+
+@contextmanager
+def close_dialog_in_event_loop(dialog_class):
+    dialog_filter = DialogEventFilter(dialog_class)
+    application = QApplication.instance()
+    application.installEventFilter(dialog_filter)
+    try:
+        yield dialog_filter
+    finally:
+        application.removeEventFilter(dialog_filter)
+
+
+def trigger_dialog_action(action, dialog_class):
+    with close_dialog_in_event_loop(dialog_class) as dialog_filter:
+        action.trigger()
+
+    assert isinstance(dialog_filter.dialog, dialog_class), "Dialog does not have the correct class"
+    assert dialog_filter.dialog.isVisible() is False, "Dialog did not close properly"
 
 
 def test_open_project_menu(ae):
@@ -87,22 +115,20 @@ def test_route_choice_menu(ae):
     assert messagebar.messages[2][0] == "Error:You need to load a project", "Level 2 error message is missing"
 
 
-def test_gis_desire_lines_menu(ae, mocker):
+def test_gis_desire_lines_menu(ae):
     from qaequilibrae.modules.gis.desire_lines_dialog import DesireLinesDialog
 
     action = ae.menuActions["Mapping"][1]
     assert action.text() == "Desire lines", "Wrong text content"
-    mock_dialog_exec(mocker, DesireLinesDialog)
-    action.trigger()
+    trigger_dialog_action(action, DesireLinesDialog)
 
 
-def test_gis_stacked_bandwidth_menu(ae, mocker):
+def test_gis_stacked_bandwidth_menu(ae):
     from qaequilibrae.modules.gis import CreateBandwidthsDialog
 
     action = ae.menuActions["Mapping"][2]
     assert action.text() == "Stacked bandwidth", "Wrong text content"
-    mock_dialog_exec(mocker, CreateBandwidthsDialog)
-    action.trigger()
+    trigger_dialog_action(action, CreateBandwidthsDialog)
 
 
 def test_gis_scenario_comparison_menu(ae):

--- a/test/test_shortest_path.py
+++ b/test/test_shortest_path.py
@@ -1,12 +1,43 @@
 import pytest
-from qgis.PyQt.QtCore import Qt
-from qgis.PyQt.QtWidgets import QDialog
+from qgis.PyQt.QtCore import QEvent, QMetaObject, QObject, Qt
+from qgis.PyQt.QtWidgets import QApplication, QDialog
 
 from qgis.core import QgsProject
 from qaequilibrae.modules.paths_procedures.show_shortest_path_dialog import ShortestPathDialog
 
 
-def test_click_configure_graph(ae_with_project, qtbot, mocker, timeoutDetector):
+class DialogEventFilter(QObject):
+    def __init__(self, dialog_class, button_name=None):
+        super().__init__()
+        self.dialog_class = dialog_class
+        self.button_name = button_name
+        self.dialog = None
+
+    def eventFilter(self, watched, event):
+        if self.dialog is None and event.type() == QEvent.Type.Show and isinstance(watched, self.dialog_class):
+            self.dialog = watched
+            if self.button_name is None:
+                QMetaObject.invokeMethod(watched, "accept", Qt.ConnectionType.QueuedConnection)
+            else:
+                button = getattr(watched, self.button_name)
+                QMetaObject.invokeMethod(button, "click", Qt.ConnectionType.QueuedConnection)
+        return super().eventFilter(watched, event)
+
+
+def run_with_dialog_event_loop(dialog_class, action, button_name=None):
+    dialog_filter = DialogEventFilter(dialog_class, button_name)
+    application = QApplication.instance()
+    application.installEventFilter(dialog_filter)
+    try:
+        action()
+    finally:
+        application.removeEventFilter(dialog_filter)
+
+    assert isinstance(dialog_filter.dialog, dialog_class), "Dialog does not have the correct class"
+    assert dialog_filter.dialog.isVisible() is False, "Dialog did not close properly"
+
+
+def test_click_configure_graph(ae_with_project, qtbot, timeoutDetector):
     """The Configure button opens the graph settings dialog."""
     from qaequilibrae.modules.common_tools import LoadGraphLayerSettingDialog
 
@@ -15,18 +46,16 @@ def test_click_configure_graph(ae_with_project, qtbot, mocker, timeoutDetector):
     qtbot.addWidget(dialog)
     qtbot.waitExposed(dialog)
 
-    def handle_exec(dialog):
-        assert isinstance(dialog, LoadGraphLayerSettingDialog), "Dialog does not have the correct class"
-        dialog.close()
-
-    mocker.patch.object(LoadGraphLayerSettingDialog, "exec", autospec=True, side_effect=handle_exec)
-    qtbot.mouseClick(dialog.configure_graph, Qt.MouseButton.LeftButton)
+    run_with_dialog_event_loop(
+        LoadGraphLayerSettingDialog,
+        lambda: qtbot.mouseClick(dialog.configure_graph, Qt.MouseButton.LeftButton),
+    )
     dialog.close()
 
 
 # Graph preparation is intertwined with the LoadGraphLayerSettingDialog, so they cannot be tested independently
 # TODO: for some reason, there is a segfault after this test is finished, couldn't find out why
-def test_prepare_graph_and_network(ae_with_project, qtbot, mocker, timeoutDetector):
+def test_prepare_graph_and_network(ae_with_project, qtbot, timeoutDetector):
     """Loading a graph through the settings dialog is what brings the picking inputs to life."""
     dialog = ShortestPathDialog(ae_with_project)
     dialog.show()
@@ -35,19 +64,16 @@ def test_prepare_graph_and_network(ae_with_project, qtbot, mocker, timeoutDetect
 
     from qaequilibrae.modules.common_tools import LoadGraphLayerSettingDialog
 
-    def handle_exec(graph_dialog):
-        assert isinstance(graph_dialog, LoadGraphLayerSettingDialog), "Dialog does not have the correct class"
-        graph_dialog.do_load_graph.click()
-        assert graph_dialog.isVisible() is False, "Dialog did not close properly"
-
-    mocker.patch.object(LoadGraphLayerSettingDialog, "exec", autospec=True, side_effect=handle_exec)
-
     # Configuring is the only thing on offer until there is a graph
     assert dialog.do_dist_matrix.isEnabled() is False
     assert dialog.path_from.isEnabled() is False
     assert dialog.path_to.isEnabled() is False
     assert dialog.configure_graph.isEnabled() is True
-    qtbot.mouseClick(dialog.configure_graph, Qt.MouseButton.LeftButton)
+    run_with_dialog_event_loop(
+        LoadGraphLayerSettingDialog,
+        lambda: qtbot.mouseClick(dialog.configure_graph, Qt.MouseButton.LeftButton),
+        button_name="do_load_graph",
+    )
 
     assert dialog.path_from.isEnabled() is True
     assert dialog.path_to.isEnabled() is True

--- a/test/test_shortest_path.py
+++ b/test/test_shortest_path.py
@@ -1,32 +1,12 @@
 import pytest
-from qgis.PyQt.QtCore import Qt, QTimer
-from qgis.PyQt.QtWidgets import QApplication, QDialog
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QDialog
 
 from qgis.core import QgsProject
 from qaequilibrae.modules.paths_procedures.show_shortest_path_dialog import ShortestPathDialog
 
 
-def wait_for_active_window(qtbot, previousClass):
-    timeout = 3000
-    window = QApplication.activeWindow()
-    while (window is None or isinstance(window, previousClass)) and timeout > 0:
-        window = QApplication.activeWindow()
-        qtbot.wait(100)
-        timeout -= 100
-    assert timeout > 0, "Waiting for window to open timed out after 3 seconds"
-    return window
-
-
-def check_if_new_active_window_matches_class(qtbot, windowClass, previousClass):
-    dialog = wait_for_active_window(qtbot, previousClass)
-    try:
-        assert isinstance(dialog, windowClass), "Active window does not match the correct window class"
-    finally:
-        dialog.close()
-        assert QApplication.activeWindow() is None, "Dialog window did not close properly"
-
-
-def test_click_configure_graph(ae_with_project, qtbot, timeoutDetector):
+def test_click_configure_graph(ae_with_project, qtbot, mocker, timeoutDetector):
     """The Configure button opens the graph settings dialog."""
     from qaequilibrae.modules.common_tools import LoadGraphLayerSettingDialog
 
@@ -35,44 +15,44 @@ def test_click_configure_graph(ae_with_project, qtbot, timeoutDetector):
     qtbot.addWidget(dialog)
     qtbot.waitExposed(dialog)
 
-    def handle_trigger():
-        check_if_new_active_window_matches_class(qtbot, LoadGraphLayerSettingDialog, ShortestPathDialog)
+    def handle_exec(dialog):
+        assert isinstance(dialog, LoadGraphLayerSettingDialog), "Dialog does not have the correct class"
+        dialog.close()
 
-    QTimer.singleShot(10, handle_trigger)
+    mocker.patch.object(LoadGraphLayerSettingDialog, "exec", autospec=True, side_effect=handle_exec)
     qtbot.mouseClick(dialog.configure_graph, Qt.MouseButton.LeftButton)
+    dialog.close()
 
 
 # Graph preparation is intertwined with the LoadGraphLayerSettingDialog, so they cannot be tested independently
 # TODO: for some reason, there is a segfault after this test is finished, couldn't find out why
-def test_prepare_graph_and_network(ae_with_project, qtbot, timeoutDetector):
+def test_prepare_graph_and_network(ae_with_project, qtbot, mocker, timeoutDetector):
     """Loading a graph through the settings dialog is what brings the picking inputs to life."""
     dialog = ShortestPathDialog(ae_with_project)
     dialog.show()
     qtbot.addWidget(dialog)
     qtbot.waitExposed(dialog)
 
-    def handle_configure_graph_trigger():
-        global graph_dialog
-        graph_dialog = wait_for_active_window(qtbot, ShortestPathDialog)
+    from qaequilibrae.modules.common_tools import LoadGraphLayerSettingDialog
 
-        def handle_do_load_graph_trigger():
-            global graph_dialog
-            assert graph_dialog.isVisible() is False, "Dialog did not close properly"
-            assert dialog.do_dist_matrix.isEnabled() is True
-            assert dialog.path_from.isEnabled() is True
-            assert dialog.path_to.isEnabled() is True
-            graph_dialog.close()
+    def handle_exec(graph_dialog):
+        assert isinstance(graph_dialog, LoadGraphLayerSettingDialog), "Dialog does not have the correct class"
+        graph_dialog.do_load_graph.click()
+        assert graph_dialog.isVisible() is False, "Dialog did not close properly"
 
-        QTimer.singleShot(10, handle_do_load_graph_trigger)
-        qtbot.mouseClick(graph_dialog.do_load_graph, Qt.MouseButton.LeftButton)
+    mocker.patch.object(LoadGraphLayerSettingDialog, "exec", autospec=True, side_effect=handle_exec)
 
     # Configuring is the only thing on offer until there is a graph
     assert dialog.do_dist_matrix.isEnabled() is False
     assert dialog.path_from.isEnabled() is False
     assert dialog.path_to.isEnabled() is False
     assert dialog.configure_graph.isEnabled() is True
-    QTimer.singleShot(10, handle_configure_graph_trigger)
     qtbot.mouseClick(dialog.configure_graph, Qt.MouseButton.LeftButton)
+
+    assert dialog.path_from.isEnabled() is True
+    assert dialog.path_to.isEnabled() is True
+    assert dialog.do_dist_matrix.isEnabled() is True
+    dialog.close()
 
 
 def test_links_layer_is_loaded_when_it_is_not_on_the_canvas(ae_with_project):


### PR DESCRIPTION
In an attempt to fix some potential race conditions (tests failing in CI on #577, working elsewhere and locally, unrelated changes) I've replaced the usage of `qtbot` and waits with ~mocking~ event filter and queueing for more deterministic CI behavior. 

~I have a solution for keeping the whole `.exec` workflow, which then wouldn't require mocking, but it's a more major change and I want to see if this fixes it first.~